### PR TITLE
Presets and size demotion

### DIFF
--- a/packages/mechanic-engine-canvas/index.js
+++ b/packages/mechanic-engine-canvas/index.js
@@ -2,7 +2,7 @@ import { Mechanic } from "mechanic-utils";
 
 const root = document.getElementById("root");
 
-const run = (functionName, func, values, isPreview) => {
+export const run = (functionName, func, values, isPreview) => {
   root.innerHTML = "";
 
   const mechanic = new Mechanic(func.params, func.settings, values);
@@ -32,5 +32,3 @@ const run = (functionName, func, values, isPreview) => {
 
   func.handler(mechanic.values, { frame: onFrame, done: onDone });
 };
-
-export default run;

--- a/packages/mechanic-engine-p5/index.js
+++ b/packages/mechanic-engine-p5/index.js
@@ -5,7 +5,7 @@ const root = document.getElementById("root");
 
 let p5Sketch;
 
-const run = (functionName, func, values, isPreview) => {
+export const run = (functionName, func, values, isPreview) => {
   if (p5Sketch) {
     p5Sketch.remove();
   }
@@ -28,5 +28,3 @@ const run = (functionName, func, values, isPreview) => {
     root
   );
 };
-
-export default run;

--- a/packages/mechanic-engine-react/.babelrc
+++ b/packages/mechanic-engine-react/.babelrc
@@ -11,7 +11,7 @@
       }
     ]
   ],
-  "plugins": ["react-hot-loader/babel", "@babel/plugin-transform-runtime"],
+  "plugins": ["@babel/plugin-transform-runtime"],
   "env": {
     "test": {
       "presets": ["@babel/preset-env"]

--- a/packages/mechanic-engine-react/index.js
+++ b/packages/mechanic-engine-react/index.js
@@ -15,8 +15,7 @@ import React from "react";
 import { render, unmountComponentAtNode } from "react-dom";
 import { Mechanic } from "mechanic-utils";
 var root = document.getElementById("root");
-
-var run = function run(functionName, func, values, isPreview) {
+export var run = function run(functionName, func, values, isPreview) {
   unmountComponentAtNode(root);
   var mechanic = new Mechanic(func.params, func.settings, values);
   var Handler = func.handler;
@@ -62,9 +61,6 @@ var run = function run(functionName, func, values, isPreview) {
     done: onDone
   })), root);
 };
-
-var _default = run;
-export default _default;
 ;
 
 (function () {
@@ -74,9 +70,8 @@ export default _default;
     return;
   }
 
-  reactHotLoader.register(root, "root", "/Users/fdoflorenzano/Projects/DSI/mechanic/packages/mechanic-react-engine/src/index.js");
-  reactHotLoader.register(run, "run", "/Users/fdoflorenzano/Projects/DSI/mechanic/packages/mechanic-react-engine/src/index.js");
-  reactHotLoader.register(_default, "default", "/Users/fdoflorenzano/Projects/DSI/mechanic/packages/mechanic-react-engine/src/index.js");
+  reactHotLoader.register(root, "root", "/Users/fdoflorenzano/Projects/DSI/mechanic/packages/mechanic-engine-react/src/index.js");
+  reactHotLoader.register(run, "run", "/Users/fdoflorenzano/Projects/DSI/mechanic/packages/mechanic-engine-react/src/index.js");
 })();
 
 ;

--- a/packages/mechanic-engine-react/index.js
+++ b/packages/mechanic-engine-react/index.js
@@ -1,16 +1,6 @@
 import _extends from "@babel/runtime/helpers/extends";
 import _regeneratorRuntime from "@babel/runtime/regenerator";
 import _asyncToGenerator from "@babel/runtime/helpers/asyncToGenerator";
-
-(function () {
-  var enterModule = typeof reactHotLoaderGlobal !== 'undefined' ? reactHotLoaderGlobal.enterModule : undefined;
-  enterModule && enterModule(module);
-})();
-
-var __signature__ = typeof reactHotLoaderGlobal !== 'undefined' ? reactHotLoaderGlobal.default.signature : function (a) {
-  return a;
-};
-
 import React from "react";
 import { render, unmountComponentAtNode } from "react-dom";
 import { Mechanic } from "mechanic-utils";
@@ -61,22 +51,3 @@ export var run = function run(functionName, func, values, isPreview) {
     done: onDone
   })), root);
 };
-;
-
-(function () {
-  var reactHotLoader = typeof reactHotLoaderGlobal !== 'undefined' ? reactHotLoaderGlobal.default : undefined;
-
-  if (!reactHotLoader) {
-    return;
-  }
-
-  reactHotLoader.register(root, "root", "/Users/fdoflorenzano/Projects/DSI/mechanic/packages/mechanic-engine-react/src/index.js");
-  reactHotLoader.register(run, "run", "/Users/fdoflorenzano/Projects/DSI/mechanic/packages/mechanic-engine-react/src/index.js");
-})();
-
-;
-
-(function () {
-  var leaveModule = typeof reactHotLoaderGlobal !== 'undefined' ? reactHotLoaderGlobal.leaveModule : undefined;
-  leaveModule && leaveModule(module);
-})();

--- a/packages/mechanic-engine-react/src/index.js
+++ b/packages/mechanic-engine-react/src/index.js
@@ -4,7 +4,7 @@ import { Mechanic } from "mechanic-utils";
 
 const root = document.getElementById("root");
 
-const run = (functionName, func, values, isPreview) => {
+export const run = (functionName, func, values, isPreview) => {
   unmountComponentAtNode(root);
   const mechanic = new Mechanic(func.params, func.settings, values);
   const Handler = func.handler;
@@ -21,5 +21,3 @@ const run = (functionName, func, values, isPreview) => {
   };
   render(<Handler {...mechanic.values} frame={onFrame} done={onDone} />, root);
 };
-
-export default run;

--- a/packages/mechanic-template/app/App.js
+++ b/packages/mechanic-template/app/App.js
@@ -2,9 +2,9 @@ import React from "react";
 import { Switch, Route, withRouter } from "react-router-dom";
 import { extractContexts } from "mechanic-utils";
 
-import Function from "./pages/Function";
-import NotFound from "./pages/NotFound";
-import Nav from "./components/Nav";
+import { Function } from "./pages/Function";
+import { NotFound } from "./pages/NotFound";
+import { Nav } from "./components/Nav";
 
 const functionContext = require.context("../functions", true, /^(.{2,})\/index\.js$/);
 const { functions } = extractContexts(functionContext);
@@ -12,7 +12,7 @@ const functionNames = Object.keys(functions);
 
 import css from "./App.css";
 
-const App = props => {
+const AppComponent = props => {
   return (
     <div className={css.root}>
       <Switch>
@@ -34,4 +34,4 @@ const App = props => {
   );
 };
 
-export default withRouter(App);
+export const App = withRouter(AppComponent);

--- a/packages/mechanic-template/app/components/Nav.js
+++ b/packages/mechanic-template/app/components/Nav.js
@@ -2,7 +2,7 @@ import React from "react";
 import { useHistory } from "react-router-dom";
 import css from "./Nav.css";
 
-const Nav = ({ name, functionsNames }) => {
+export const Nav = ({ name, functionsNames }) => {
   const history = useHistory();
 
   return (
@@ -23,5 +23,3 @@ const Nav = ({ name, functionsNames }) => {
     </div>
   );
 };
-
-export default Nav;

--- a/packages/mechanic-template/app/components/ParamInput.js
+++ b/packages/mechanic-template/app/components/ParamInput.js
@@ -2,9 +2,9 @@ import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
 import css from "./ParamInput.css";
-import Input from "./input/Input";
-import Select from "./input/Select";
-import Toggle from "./input/Toggle";
+import { Input } from "./input/Input";
+import { Select } from "./input/Select";
+import { Toggle } from "./input/Toggle";
 
 export const ParamInput = ({ name, className, value, options, onChange, children }) => {
   const { type, choices } = options;
@@ -56,8 +56,6 @@ export const ParamInput = ({ name, className, value, options, onChange, children
     </Input>
   );
 };
-
-export default ParamInput;
 
 ParamInput.defaultProps = {
   onChange: () => {}

--- a/packages/mechanic-template/app/components/input/Button.js
+++ b/packages/mechanic-template/app/components/input/Button.js
@@ -15,8 +15,6 @@ export const Button = ({ className, variant, onClick, children, disabled }) => {
   );
 };
 
-export default Button;
-
 Button.defaultProps = {
   onClick: () => {}
 };

--- a/packages/mechanic-template/app/components/input/Checkbox.js
+++ b/packages/mechanic-template/app/components/input/Checkbox.js
@@ -48,5 +48,3 @@ Checkbox.propTypes = {
   checked: PropTypes.bool,
   disabled: PropTypes.bool
 };
-
-export default Checkbox;

--- a/packages/mechanic-template/app/components/input/Input.js
+++ b/packages/mechanic-template/app/components/input/Input.js
@@ -66,8 +66,6 @@ export const Input = props => {
   );
 };
 
-export default Input;
-
 Input.defaultProps = {
   type: "text",
   onChange: () => {},

--- a/packages/mechanic-template/app/components/input/Radio.js
+++ b/packages/mechanic-template/app/components/input/Radio.js
@@ -37,8 +37,6 @@ export const Radio = props => {
   );
 };
 
-export default Radio;
-
 Radio.propTypes = {
   name: PropTypes.string,
   value: PropTypes.string,

--- a/packages/mechanic-template/app/components/input/Select.js
+++ b/packages/mechanic-template/app/components/input/Select.js
@@ -69,8 +69,6 @@ export const Select = props => {
   );
 };
 
-export default Select;
-
 Select.defaultProps = {
   placeholder: "Select..."
 };

--- a/packages/mechanic-template/app/components/input/Toggle.css
+++ b/packages/mechanic-template/app/components/input/Toggle.css
@@ -8,13 +8,15 @@
   position: relative;
   display: block;
   -webkit-appearance: none;
-  cursor: pointer;
   min-width: 120px;
   padding: 0.5em 1em;
   margin: 0;
   background-color: white;
   border: 1px solid var(--text);
-  &:active {
+  &:not([disabled]) {
+    cursor: pointer;
+  }
+  &:active:not([disabled]) {
     background-color: var(--blue);
     color: white;
   }

--- a/packages/mechanic-template/app/components/input/Toggle.js
+++ b/packages/mechanic-template/app/components/input/Toggle.js
@@ -16,8 +16,6 @@ export const Toggle = ({ className, variant, status, onClick, children, disabled
   );
 };
 
-export default Toggle;
-
 Toggle.defaultProps = {
   onClick: () => {}
 };

--- a/packages/mechanic-template/app/index.js
+++ b/packages/mechanic-template/app/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { render } from "react-dom";
 import { BrowserRouter } from "react-router-dom";
-import App from "./App.js";
+import { App } from "./App.js";
 import "./index.css";
 
 const root = document.getElementById("root");

--- a/packages/mechanic-template/app/pages/Function.js
+++ b/packages/mechanic-template/app/pages/Function.js
@@ -9,26 +9,38 @@ import { ParamInput } from "../components/ParamInput";
 import css from "./Function.css";
 
 export const Function = ({ name, exports, children }) => {
-  const [values, setValues] = useState({});
-  const [fastPreview, setFastPreview] = useState(true);
+  const [values, setValues] = useState({ preset: "default" });
+  const [scaleToFit, setScaleToFit] = useState(true);
 
   const mainRef = useRef();
   const randomSeed = useRef();
   const iframe = useRef();
 
-  const { params } = exports;
-  const { size, ...optional } = params;
-  const sizes = size !== undefined ? Object.keys(size) : [];
+  const { params, presets: otherPresets } = exports;
+  const presets = ["default"].concat(Object.keys(otherPresets ? otherPresets : {}));
 
   const handleOnChange = (e, name, value) => {
-    setValues(values => Object.assign({}, values, { [name]: value }));
+    const sources = [{ [name]: value }];
+    if (name === "preset") {
+      if (value === "default") {
+        sources.push(
+          Object.entries(params).reduce((source, param) => {
+            source[param[0]] = param[1].default;
+            return source;
+          }, {})
+        );
+      } else {
+        sources.push(otherPresets[value]);
+      }
+    }
+    setValues(values => Object.assign({}, values, ...sources));
   };
 
   const handlePreview = async () => {
     const vals = Object.assign({}, values);
-    if (fastPreview) {
+    if (scaleToFit) {
       const bounds = mainRef.current.getBoundingClientRect();
-      vals.scaleDownToFit = {
+      vals.scaleToFit = {
         width: bounds.width - 100,
         height: bounds.height - 100
       };
@@ -71,27 +83,25 @@ export const Function = ({ name, exports, children }) => {
         <div className={css.line} />
         <div className={css.paramsWrapper}>
           <div className={css.params}>
-            {size && (
-              <div className={css.param}>
-                <div className={classnames(css.row, css.strong)}>
-                  <span className={classnames(css.grow, css.paramlabel)}>size</span>
-                </div>
-                <div className={css.row}>
-                  <Select
-                    className={css.grow}
-                    onChange={handleOnChange}
-                    name="size"
-                    value={values.size || "default"}>
-                    {sizes.map(size => (
-                      <option key={`size-${size}`} value={size}>
-                        {size} ({params.size[size].width}x{params.size[size].height})
-                      </option>
-                    ))}
-                  </Select>
-                </div>
+            <div className={css.param}>
+              <div className={classnames(css.row, css.strong)}>
+                <span className={classnames(css.grow, css.paramlabel)}>preset</span>
               </div>
-            )}
-            {Object.entries(optional).map(([name, param]) => (
+              <div className={css.row}>
+                <Select
+                  className={css.grow}
+                  onChange={handleOnChange}
+                  name="preset"
+                  value={values.preset}>
+                  {presets.map(preset => (
+                    <option key={`preset-${preset}`} value={preset}>
+                      {preset}
+                    </option>
+                  ))}
+                </Select>
+              </div>
+            </div>
+            {Object.entries(params).map(([name, param]) => (
               <div key={`param-${name}`} className={css.param}>
                 <div className={classnames(css.row, css.strong)}>
                   <span className={classnames(css.grow, css.paramlabel)}>{name}</span>
@@ -115,9 +125,9 @@ export const Function = ({ name, exports, children }) => {
           <div className={classnames(css.row, css.strong)}>
             <Toggle
               className={css.grow}
-              status={fastPreview}
-              onClick={() => setFastPreview(fastPreview => !fastPreview)}>
-              {fastPreview ? "Fast Preview On" : "Fast Preview Off"}
+              status={scaleToFit}
+              onClick={() => setScaleToFit(scaleToFit => !scaleToFit)}>
+              {scaleToFit ? "Scale to fit On" : "Scale to fit Off"}
             </Toggle>
           </div>
           <div className={css.sep} />

--- a/packages/mechanic-template/app/pages/Function.js
+++ b/packages/mechanic-template/app/pages/Function.js
@@ -36,9 +36,11 @@ export const Function = ({ name, exports, children }) => {
     setValues(values => Object.assign({}, values, ...sources));
   };
 
+  const canScale = params.width && params.height;
+
   const handlePreview = async () => {
     const vals = Object.assign({}, values);
-    if (scaleToFit) {
+    if (canScale && scaleToFit) {
       const bounds = mainRef.current.getBoundingClientRect();
       vals.scaleToFit = {
         width: bounds.width - 100,
@@ -125,9 +127,10 @@ export const Function = ({ name, exports, children }) => {
           <div className={classnames(css.row, css.strong)}>
             <Toggle
               className={css.grow}
-              status={scaleToFit}
+              status={canScale && scaleToFit}
+              disabled={!canScale}
               onClick={() => setScaleToFit(scaleToFit => !scaleToFit)}>
-              {scaleToFit ? "Scale to fit On" : "Scale to fit Off"}
+              Scale to fit {canScale && scaleToFit ? "On" : "Off"}
             </Toggle>
           </div>
           <div className={css.sep} />

--- a/packages/mechanic-template/app/pages/Function.js
+++ b/packages/mechanic-template/app/pages/Function.js
@@ -130,7 +130,11 @@ export const Function = ({ name, exports, children }) => {
               status={canScale && scaleToFit}
               disabled={!canScale}
               onClick={() => setScaleToFit(scaleToFit => !scaleToFit)}>
-              Scale to fit {canScale && scaleToFit ? "On" : "Off"}
+              {canScale
+                ? scaleToFit
+                  ? "Scale to fit On"
+                  : "Scale to fit Off"
+                : "Params missing for scaling"}
             </Toggle>
           </div>
           <div className={css.sep} />

--- a/packages/mechanic-template/app/pages/Function.js
+++ b/packages/mechanic-template/app/pages/Function.js
@@ -2,13 +2,13 @@ import React, { useState, useRef, useEffect } from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
 import Mousetrap from "mousetrap";
-import Select from "../components/input/Select";
-import Button from "../components/input/Button";
-import Toggle from "../components/input/Toggle";
-import ParamInput from "../components/ParamInput";
+import { Select } from "../components/input/Select";
+import { Button } from "../components/input/Button";
+import { Toggle } from "../components/input/Toggle";
+import { ParamInput } from "../components/ParamInput";
 import css from "./Function.css";
 
-const Function = ({ name, exports, children }) => {
+export const Function = ({ name, exports, children }) => {
   const [values, setValues] = useState({});
   const [fastPreview, setFastPreview] = useState(true);
 
@@ -149,5 +149,3 @@ Function.propTypes = {
     settings: PropTypes.object.isRequired
   })
 };
-
-export default Function;

--- a/packages/mechanic-template/app/pages/NotFound.js
+++ b/packages/mechanic-template/app/pages/NotFound.js
@@ -1,12 +1,10 @@
 import React from "react";
 import css from "./NotFound.css";
 
-const NotFound = props => {
+export const NotFound = props => {
   return (
     <div className={css.root}>
       <p>Not found</p>
     </div>
   );
 };
-
-export default NotFound;

--- a/packages/mechanic-template/functions/canvasImage/index.js
+++ b/packages/mechanic-template/functions/canvasImage/index.js
@@ -1,5 +1,3 @@
-import engine from "mechanic-engine-canvas";
-
 export const handler = (params, mechanic) => {
   const {
     width,
@@ -102,5 +100,5 @@ export const params = {
 };
 
 export const settings = {
-  engine
+  engine: require("mechanic-engine-canvas").run
 };

--- a/packages/mechanic-template/functions/canvasImage/index.js
+++ b/packages/mechanic-template/functions/canvasImage/index.js
@@ -42,23 +42,13 @@ export const handler = (params, mechanic) => {
 // We will probably do this with a webpack loader
 // We also need a nicer API to create this file
 export const params = {
-  size: {
-    default: {
-      width: 400,
-      height: 300
-    },
-    medium: {
-      width: 800,
-      height: 600
-    },
-    large: {
-      width: 1600,
-      height: 1200
-    },
-    xlarge: {
-      width: 3200,
-      height: 2400
-    }
+  width: {
+    type: "integer",
+    default: 400
+  },
+  height: {
+    type: "integer",
+    default: 300
   },
   primaryColor: {
     type: "string",
@@ -96,6 +86,21 @@ export const params = {
   rightMargin: {
     type: "integer",
     default: 100
+  }
+};
+
+export const presets = {
+  medium: {
+    width: 800,
+    height: 600
+  },
+  large: {
+    width: 1600,
+    height: 1200
+  },
+  xlarge: {
+    width: 3200,
+    height: 2400
   }
 };
 

--- a/packages/mechanic-template/functions/canvasVideo/index.js
+++ b/packages/mechanic-template/functions/canvasVideo/index.js
@@ -33,23 +33,13 @@ export const handler = async (params, mechanic) => {
 // We will probably do this with a webpack loader
 // We also need a nicer API to create this file
 export const params = {
-  size: {
-    default: {
-      width: 400,
-      height: 300
-    },
-    medium: {
-      width: 800,
-      height: 600
-    },
-    large: {
-      width: 1600,
-      height: 1200
-    },
-    xlarge: {
-      width: 3200,
-      height: 2400
-    }
+  width: {
+    type: "integer",
+    default: 400
+  },
+  height: {
+    type: "integer",
+    default: 300
   },
   primaryColor: {
     type: "string",
@@ -62,6 +52,21 @@ export const params = {
   maxFrames: {
     type: "integer",
     default: 100
+  }
+};
+
+export const presets = {
+  medium: {
+    width: 800,
+    height: 600
+  },
+  large: {
+    width: 1600,
+    height: 1200
+  },
+  xlarge: {
+    width: 3200,
+    height: 2400
   }
 };
 

--- a/packages/mechanic-template/functions/canvasVideo/index.js
+++ b/packages/mechanic-template/functions/canvasVideo/index.js
@@ -1,5 +1,3 @@
-import engine from "mechanic-engine-canvas";
-
 export const handler = async (params, mechanic) => {
   const { width, height, primaryColor, secondaryColor, maxFrames } = params;
 
@@ -68,6 +66,6 @@ export const params = {
 };
 
 export const settings = {
-  engine,
+  engine: require("mechanic-engine-canvas").run,
   animated: true
 };

--- a/packages/mechanic-template/functions/p5Animation/index.js
+++ b/packages/mechanic-template/functions/p5Animation/index.js
@@ -27,23 +27,13 @@ export const handler = async (sketch, params, mechanic) => {
 // We will probably do this with a webpack loader
 // We also need a nicer API to create this file
 export const params = {
-  size: {
-    default: {
-      width: 400,
-      height: 300
-    },
-    medium: {
-      width: 800,
-      height: 600
-    },
-    large: {
-      width: 1600,
-      height: 1200
-    },
-    xlarge: {
-      width: 3200,
-      height: 2400
-    }
+  width: {
+    type: "integer",
+    default: 400
+  },
+  height: {
+    type: "integer",
+    default: 300
   },
   primaryColor: {
     type: "string",
@@ -56,6 +46,21 @@ export const params = {
   maxFrames: {
     type: "integer",
     default: 100
+  }
+};
+
+export const presets = {
+  medium: {
+    width: 800,
+    height: 600
+  },
+  large: {
+    width: 1600,
+    height: 1200
+  },
+  xlarge: {
+    width: 3200,
+    height: 2400
   }
 };
 

--- a/packages/mechanic-template/functions/p5Animation/index.js
+++ b/packages/mechanic-template/functions/p5Animation/index.js
@@ -1,5 +1,3 @@
-import engine from "mechanic-engine-p5";
-
 export const handler = async (sketch, params, mechanic) => {
   const { width, height, primaryColor, secondaryColor, maxFrames } = params;
 
@@ -62,6 +60,6 @@ export const params = {
 };
 
 export const settings = {
-  engine,
+  engine: require("mechanic-engine-p5").run,
   animated: true
 };

--- a/packages/mechanic-template/functions/randomImage/index.js
+++ b/packages/mechanic-template/functions/randomImage/index.js
@@ -1,5 +1,3 @@
-import engine from "mechanic-engine-canvas";
-
 export const handler = (params, mechanic) => {
   const { width, height, background, color1, color2, numberOfSquares } = params;
   const colors = [color1, color2];
@@ -49,6 +47,6 @@ export const params = {
 };
 
 export const settings = {
-  engine,
+  engine: require("mechanic-engine-canvas").run,
   usesRandom: true
 };

--- a/packages/mechanic-template/functions/randomImage/index.js
+++ b/packages/mechanic-template/functions/randomImage/index.js
@@ -20,11 +20,13 @@ export const handler = (params, mechanic) => {
 // We will probably do this with a webpack loader
 // We also need a nicer API to create this file
 export const params = {
-  size: {
-    default: {
-      width: 1600,
-      height: 1600
-    }
+  width: {
+    type: "integer",
+    default: 1600
+  },
+  height: {
+    type: "integer",
+    default: 1600
   },
   background: {
     type: "string",

--- a/packages/mechanic-template/functions/reactImage/index.js
+++ b/packages/mechanic-template/functions/reactImage/index.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 
-export const handler = ({ width, height, done, background, fill, hasInnerHole }) => {
+export const handler = ({ width, done, background, fill, hasInnerHole }) => {
+  const height = width;
   useEffect(() => {
     done();
   }, []);
@@ -34,10 +35,6 @@ export const handler = ({ width, height, done, background, fill, hasInnerHole })
 // We also need a nicer API to create this file
 export const params = {
   width: {
-    type: "integer",
-    default: 600
-  },
-  height: {
     type: "integer",
     default: 600
   },

--- a/packages/mechanic-template/functions/reactImage/index.js
+++ b/packages/mechanic-template/functions/reactImage/index.js
@@ -33,11 +33,13 @@ export const handler = ({ width, height, done, background, fill, hasInnerHole })
 // We will probably do this with a webpack loader
 // We also need a nicer API to create this file
 export const params = {
-  size: {
-    default: {
-      width: 600,
-      height: 600
-    }
+  width: {
+    type: "integer",
+    default: 600
+  },
+  height: {
+    type: "integer",
+    default: 600
   },
   background: {
     type: "string",

--- a/packages/mechanic-template/functions/reactImage/index.js
+++ b/packages/mechanic-template/functions/reactImage/index.js
@@ -1,5 +1,4 @@
 import React, { useEffect } from "react";
-import engine from "mechanic-engine-react";
 
 export const handler = ({ width, height, done, background, fill, hasInnerHole }) => {
   useEffect(() => {
@@ -57,5 +56,5 @@ export const params = {
 };
 
 export const settings = {
-  engine
+  engine: require("mechanic-engine-react").run
 };

--- a/packages/mechanic-template/functions/reactVideo/index.js
+++ b/packages/mechanic-template/functions/reactVideo/index.js
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useRef } from "react";
 
-export const handler = ({ width, height, frame, done, background, fill }) => {
+export const handler = ({ height, frame, done, background, fill }) => {
+  const width = height;
+
   const isPlaying = useRef(true);
   const frameCount = useDrawLoop(isPlaying.current);
 
@@ -28,10 +30,6 @@ export const handler = ({ width, height, frame, done, background, fill }) => {
 // We will probably do this with a webpack loader
 // We also need a nicer API to create this file
 export const params = {
-  width: {
-    type: "integer",
-    default: 600
-  },
   height: {
     type: "integer",
     default: 600

--- a/packages/mechanic-template/functions/reactVideo/index.js
+++ b/packages/mechanic-template/functions/reactVideo/index.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useRef } from "react";
-import engine from "mechanic-engine-react";
 
 export const handler = ({ width, height, frame, done, background, fill }) => {
   const isPlaying = useRef(true);
@@ -48,7 +47,7 @@ export const params = {
 };
 
 export const settings = {
-  engine,
+  engine: require("mechanic-engine-react").run,
   animated: true
 };
 

--- a/packages/mechanic-template/functions/reactVideo/index.js
+++ b/packages/mechanic-template/functions/reactVideo/index.js
@@ -28,11 +28,13 @@ export const handler = ({ width, height, frame, done, background, fill }) => {
 // We will probably do this with a webpack loader
 // We also need a nicer API to create this file
 export const params = {
-  size: {
-    default: {
-      width: 600,
-      height: 600
-    }
+  width: {
+    type: "integer",
+    default: 600
+  },
+  height: {
+    type: "integer",
+    default: 600
   },
   background: {
     type: "string",

--- a/packages/mechanic-template/functions/svgImage/index.js
+++ b/packages/mechanic-template/functions/svgImage/index.js
@@ -13,23 +13,28 @@ export const handler = (params, mechanic) => {
 // We will probably do this with a webpack loader
 // We also need a nicer API to create this file
 export const params = {
-  size: {
-    default: {
-      width: 400,
-      height: 300
-    },
-    medium: {
-      width: 800,
-      height: 600
-    },
-    large: {
-      width: 1600,
-      height: 1200
-    },
-    xlarge: {
-      width: 3200,
-      height: 2400
-    }
+  width: {
+    type: "integer",
+    default: 400
+  },
+  height: {
+    type: "integer",
+    default: 300
+  }
+};
+
+export const presets = {
+  medium: {
+    width: 800,
+    height: 600
+  },
+  large: {
+    width: 1600,
+    height: 1200
+  },
+  xlarge: {
+    width: 3200,
+    height: 2400
   }
 };
 

--- a/packages/mechanic-template/functions/svgVideo/index.js
+++ b/packages/mechanic-template/functions/svgVideo/index.js
@@ -28,23 +28,28 @@ export const handler = async (params, mechanic) => {
 // We will probably do this with a webpack loader
 // We also need a nicer API to create this file
 export const params = {
-  size: {
-    default: {
-      width: 400,
-      height: 300
-    },
-    medium: {
-      width: 800,
-      height: 600
-    },
-    large: {
-      width: 1600,
-      height: 1200
-    },
-    xlarge: {
-      width: 3200,
-      height: 2400
-    }
+  width: {
+    type: "integer",
+    default: 400
+  },
+  height: {
+    type: "integer",
+    default: 300
+  }
+};
+
+export const presets = {
+  medium: {
+    width: 800,
+    height: 600
+  },
+  large: {
+    width: 1600,
+    height: 1200
+  },
+  xlarge: {
+    width: 3200,
+    height: 2400
   }
 };
 

--- a/packages/mechanic-utils/.prettierrc
+++ b/packages/mechanic-utils/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "printWidth": 100,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "useTabs": false,
+  "arrowParens": "avoid",
+  "jsxBracketSameLine": true,
+  "trailingComma": "none"
+}

--- a/packages/mechanic-utils/src/mechanic-error.js
+++ b/packages/mechanic-utils/src/mechanic-error.js
@@ -1,5 +1,5 @@
 /**
- * Am error class for Mechanic-related issues
+ * An error class for Mechanic-related issues
  */
 class MechanicError extends Error {
   constructor(message) {

--- a/packages/mechanic-utils/src/mechanic-validation.js
+++ b/packages/mechanic-utils/src/mechanic-validation.js
@@ -83,7 +83,7 @@ const prepareValues = (params, settings, values) => {
   });
 
   // Scale down to fit
-  if (values.scaleToFit) {
+  if (values.scaleToFit && vals.width && vals.height) {
     const ratioWidth = values.scaleToFit.width ? values.scaleToFit.width / vals.width : 1;
     const ratioHeight = values.scaleToFit.height ? values.scaleToFit.height / vals.height : 1;
     if (ratioWidth < 1 || ratioHeight < 1) {

--- a/packages/mechanic-utils/src/mechanic-validation.js
+++ b/packages/mechanic-utils/src/mechanic-validation.js
@@ -1,6 +1,6 @@
 import seedrandom from "seedrandom";
 
-const isObject = (obj) => obj && typeof obj === "object";
+const isObject = obj => obj && typeof obj === "object";
 const hasKey = (obj, key) => obj.hasOwnProperty(key);
 const supportedTypes = ["string", "integer", "boolean"];
 
@@ -8,22 +8,15 @@ const supportedTypes = ["string", "integer", "boolean"];
  * Receives the parameter template and checks that it is valid
  * @param {object} params - Parameter template from the design function
  */
-const validateParams = (params) => {
-  if (!isObject(params.size)) {
-    return `Parameter template must have a size object`;
-  }
-  const { size, ...optionals } = params;
-  if (!isObject(size.default)) {
-    return `Parameter template must have default size`;
-  }
-  for (let param in optionals) {
-    if (!hasKey(optionals[param], "type")) {
+const validateParams = params => {
+  for (let param in params) {
+    if (!hasKey(params[param], "type")) {
       return `Parameter ${param} must have ${key} property`;
     }
-    if (!supportedTypes.includes(optionals[param].type)) {
-      return `Parameter of type ${optionals[param].type} not supported, expected: ${supportedTypes}`;
+    if (!supportedTypes.includes(params[param].type)) {
+      return `Parameter of type ${params[param].type} not supported, expected: ${supportedTypes}`;
     }
-    if (!hasKey(optionals[param], "default")) {
+    if (!hasKey(params[param], "default")) {
       return `Parameter ${param} must have ${key} property`;
     }
   }
@@ -51,7 +44,7 @@ const validateValues = (params, values = {}) => {
  * Receives the settings from a function and validates it.
  * @param {object} settings - Design function settings
  */
-const validateSettings = (settings) => {
+const validateSettings = settings => {
   if (!hasKey(settings, "engine")) {
     return `The design function must have specify an engine in settings`;
   }
@@ -67,27 +60,7 @@ const validateSettings = (settings) => {
  * @param {object} values - Values for some or all of the parameters
  */
 const prepareValues = (params, settings, values) => {
-  // Size
-  const size = values.size || "default";
-  const vals = Object.assign({}, values, {
-    width: params.size[size].width,
-    height: params.size[size].height,
-  });
-
-  // Scale down to fit
-  if (values.scaleDownToFit) {
-    const ratioWidth = values.scaleDownToFit.width
-      ? values.scaleDownToFit.width / vals.width
-      : 1;
-    const ratioHeight = values.scaleDownToFit.height
-      ? values.scaleDownToFit.height / vals.height
-      : 1;
-    if (ratioWidth < 1 || ratioHeight < 1) {
-      const ratio = ratioWidth < ratioHeight ? ratioWidth : ratioHeight;
-      vals.width = Math.floor(vals.width * ratio);
-      vals.height = Math.floor(vals.height * ratio);
-    }
-  }
+  const vals = Object.assign({}, values);
 
   // Random seed
   if (settings.usesRandom) {
@@ -97,9 +70,8 @@ const prepareValues = (params, settings, values) => {
     seedrandom(vals.randomSeed, { global: true });
   }
 
-  // Other params
-
-  Object.keys(params).forEach((key) => {
+  // Params
+  Object.keys(params).forEach(key => {
     if (key != "size") {
       let val = values[key] === undefined ? params[key].default : values[key];
       if (params[key].type == "integer") {
@@ -110,6 +82,17 @@ const prepareValues = (params, settings, values) => {
     }
   });
 
+  // Scale down to fit
+  if (values.scaleToFit) {
+    const ratioWidth = values.scaleToFit.width ? values.scaleToFit.width / vals.width : 1;
+    const ratioHeight = values.scaleToFit.height ? values.scaleToFit.height / vals.height : 1;
+    if (ratioWidth < 1 || ratioHeight < 1) {
+      const ratio = ratioWidth < ratioHeight ? ratioWidth : ratioHeight;
+      vals.width = Math.floor(vals.width * ratio);
+      vals.height = Math.floor(vals.height * ratio);
+    }
+  }
+
   return vals;
 };
 
@@ -117,7 +100,7 @@ const prepareValues = (params, settings, values) => {
  * Validates that a DOM element is SVG or Canvas
  * @param {object} el - A DOM element to check
  */
-const validateEl = (el) => {
+const validateEl = el => {
   if (el instanceof SVGElement || el instanceof HTMLCanvasElement) {
     return null;
   }
@@ -128,7 +111,7 @@ const validateEl = (el) => {
  * Checks whether a DOM element is instance of SVGElement
  * @param {object} el - A DOM element to check
  */
-const isSVG = (el) => el instanceof SVGElement;
+const isSVG = el => el instanceof SVGElement;
 
 export {
   isObject,
@@ -139,5 +122,5 @@ export {
   validateSettings,
   prepareValues,
   isSVG,
-  validateEl,
+  validateEl
 };

--- a/packages/mechanic-utils/src/mechanic.js
+++ b/packages/mechanic-utils/src/mechanic.js
@@ -1,5 +1,5 @@
 import { download } from "./download";
-import WebMWriter from "./webm-writer";
+import { WebMWriter } from "./webm-writer";
 import { svgToDataUrl, dataUrlToCanvas, getTimeStamp } from "./mechanic-utils";
 import * as validation from "./mechanic-validation";
 import { MechanicError } from "./mechanic-error";

--- a/packages/mechanic-utils/src/webm-writer.js
+++ b/packages/mechanic-utils/src/webm-writer.js
@@ -1319,4 +1319,4 @@ const WebMWriterClass = function (ArrayBufferDataStream, BlobBuffer) {
   };
 };
 
-export default WebMWriterClass(ArrayBufferDataStream, BlobBuffer);
+export const WebMWriter = WebMWriterClass(ArrayBufferDataStream, BlobBuffer);


### PR DESCRIPTION
Did another two items in issue #19:
- Remove size param and replace with params and presets. width and height are not special. Must have defaults.
- “Fast-preview” → “Scale to fit” (Works only for design functions that draw relative to the canvas size)

I did it so that it always created a "default" preset option that sets every parameter into its default value, and also adds any option exported by the user in an `presets` object.

It also removes all "special" validation steps for size parameter. 

One aspect that wasn't discussed (I think) is the scaling effect now that the `width` and `height` parameters aren't always present. For now, it checks if those parameters are present, if they are and scaling down is active, then the passed down values are scaled. I was thinking that if scaling is active but one of the parameters are not present, then a bounding window object can be passed down. But I'm not sure.