### PR TITLE
Editable params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for `"editable"` property in params. It disables the input in case of non editable result.
+
+### Changed
+
+- `ParamInput` component doesn't receive single `value` prop, but `values` prop with the whole object of values.
+
 ## [0.2.8] - 2021-07-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 To start using right away and create a new Mechanic project, run the following:
 
 ```
-$ npm init @designsystemsinternational/mechanic@latest mechanic-project
+npm init @designsystemsinternational/mechanic@latest mechanic-project
 ```
 
 This will build a new base Mechanic project, with one **design function**! Follow the CLI instructions to customize, install and start running.
@@ -59,7 +59,7 @@ To publish all packages in the repo, run `npm run publish:local`. To publish an 
 
 Then in the project to test the package(s), before installing dependencies run `yalc add [package]` for all packages you wish to test. Then install normally with `npm i`.
 
-For any other needs, check [`yalc's documentation](https://github.com/wclr/yalc).
+For any other needs, check [`yalc`'s documentation](https://github.com/wclr/yalc).
 
 ## Publish
 

--- a/packages/dsi-logo-maker/functions/logoAnimatedCanvas/index.js
+++ b/packages/dsi-logo-maker/functions/logoAnimatedCanvas/index.js
@@ -98,7 +98,7 @@ export const params = {
   },
   colorMode: {
     type: "text",
-    options: ["Random Flag", "Pick Flag", "Custom Colors"],
+    options: ["Random Flag", "Pick Flag", "Custom Colors", 2],
     default: "Random Flag",
   },
   flag: {

--- a/packages/dsi-logo-maker/functions/logoAnimatedCanvas/index.js
+++ b/packages/dsi-logo-maker/functions/logoAnimatedCanvas/index.js
@@ -105,21 +105,25 @@ export const params = {
     type: "text",
     options: flagNames,
     default: flagNames[0],
+    editable: (params) => params.colorMode === "Pick Flag",
   },
   firstColor: {
     type: "color",
     model: "hex",
     default: "#11457e",
+    editable: (params) => params.colorMode === "Custom Colors",
   },
   secondColor: {
     type: "color",
     model: "hex",
     default: "#d7141a",
+    editable: (params) => params.colorMode === "Custom Colors",
   },
   thirdColor: {
     type: "color",
     model: "hex",
     default: "#f1f1f1",
+    editable: (params) => params.colorMode === "Custom Colors",
   },
   offset: {
     type: "number",

--- a/packages/dsi-logo-maker/functions/logoAnimatedCanvas/index.js
+++ b/packages/dsi-logo-maker/functions/logoAnimatedCanvas/index.js
@@ -98,7 +98,7 @@ export const params = {
   },
   colorMode: {
     type: "text",
-    options: ["Random Flag", "Pick Flag", "Custom Colors", 2],
+    options: ["Random Flag", "Pick Flag", "Custom Colors"],
     default: "Random Flag",
   },
   flag: {

--- a/packages/dsi-logo-maker/functions/logoAnimatedSVG/index.js
+++ b/packages/dsi-logo-maker/functions/logoAnimatedSVG/index.js
@@ -118,21 +118,25 @@ export const params = {
     type: "text",
     options: flagNames,
     default: flagNames[0],
+    editable: (params) => params.colorMode === "Pick Flag",
   },
   firstColor: {
     type: "color",
     model: "hex",
     default: "#11457e",
+    editable: (params) => params.colorMode === "Custom Colors",
   },
   secondColor: {
     type: "color",
     model: "hex",
     default: "#d7141a",
+    editable: (params) => params.colorMode === "Custom Colors",
   },
   thirdColor: {
     type: "color",
     model: "hex",
     default: "#f1f1f1",
+    editable: (params) => params.colorMode === "Custom Colors",
   },
   offset: {
     type: "number",

--- a/packages/dsi-logo-maker/functions/logoCanvas/index.js
+++ b/packages/dsi-logo-maker/functions/logoCanvas/index.js
@@ -76,21 +76,25 @@ export const params = {
     type: "text",
     options: flagNames,
     default: flagNames[0],
+    editable: (params) => params.colorMode === "Pick Flag",
   },
   firstColor: {
     type: "color",
     model: "hex",
     default: "#11457e",
+    editable: (params) => params.colorMode === "Custom Colors",
   },
   secondColor: {
     type: "color",
     model: "hex",
     default: "#d7141a",
+    editable: (params) => params.colorMode === "Custom Colors",
   },
   thirdColor: {
     type: "color",
     model: "hex",
     default: "#f1f1f1",
+    editable: (params) => params.colorMode === "Custom Colors",
   },
   offset: {
     type: "number",

--- a/packages/dsi-logo-maker/functions/logoSVG/index.js
+++ b/packages/dsi-logo-maker/functions/logoSVG/index.js
@@ -71,21 +71,25 @@ export const params = {
     type: "text",
     options: flagNames,
     default: flagNames[0],
+    editable: (params) => params.colorMode === "Pick Flag",
   },
   firstColor: {
     type: "color",
     model: "hex",
     default: "#11457e",
+    editable: (params) => params.colorMode === "Custom Colors",
   },
   secondColor: {
     type: "color",
     model: "hex",
     default: "#d7141a",
+    editable: (params) => params.colorMode === "Custom Colors",
   },
   thirdColor: {
     type: "color",
     model: "hex",
     default: "#f1f1f1",
+    editable: (params) => params.colorMode === "Custom Colors",
   },
   offset: {
     type: "number",

--- a/packages/dsi-logo-maker/functions/pinSVG/index.js
+++ b/packages/dsi-logo-maker/functions/pinSVG/index.js
@@ -100,21 +100,25 @@ export const params = {
     type: "text",
     options: flagNames,
     default: flagNames[0],
+    editable: (params) => params.colorMode === "Pick Flag",
   },
   firstColor: {
     type: "color",
     model: "hex",
     default: "#11457e",
+    editable: (params) => params.colorMode === "Custom Colors",
   },
   secondColor: {
     type: "color",
     model: "hex",
     default: "#d7141a",
+    editable: (params) => params.colorMode === "Custom Colors",
   },
   thirdColor: {
     type: "color",
     model: "hex",
     default: "#f1f1f1",
+    editable: (params) => params.colorMode === "Custom Colors",
   },
   offset: {
     type: "number",

--- a/packages/mechanic-ui-components/CHANGELOG.md
+++ b/packages/mechanic-ui-components/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Support for `"editable"` property in params. It disables the input in case of non editable result.
+- Extended base stylings for disabled inputs.
+
+### Changed
+
+- `ParamInput` component doesn't receive single `value` prop, but `values` prop with the whole object of values. This enables the `"editable"` function evaluation.
+
 ## 0.2.7 - 2021-07-13
 
 First logged release

--- a/packages/mechanic-ui-components/app/index.js
+++ b/packages/mechanic-ui-components/app/index.js
@@ -13,7 +13,7 @@ import {
 const root = document.getElementById("root");
 
 const App = () => {
-  const [vals, setVals] = useState({
+  const [values, setValues] = useState({
     text: "Hello world",
     toggle: true,
     number: 400,
@@ -28,17 +28,18 @@ const App = () => {
 
   const handleChange = (e, name, value) => {
     console.info(name, typeof value, value);
-    setVals(vals => Object.assign({}, vals, { [name]: value }));
+    setValues(values => Object.assign({}, values, { [name]: value }));
   };
 
   const blockStyle = { width: "300px", display: "inline-block", margin: "1em" };
+  const twoBlockStyle = { width: "600px", display: "inline-block", margin: "1em" };
   return (
     <>
       <h3>ParamInput component</h3>
       <div style={blockStyle}>
         <ParamInput
           name={"text"}
-          value={vals.text}
+          values={values}
           attributes={{
             type: "text",
             default: "Hi",
@@ -50,7 +51,7 @@ const App = () => {
       <div style={blockStyle}>
         <ParamInput
           name={"toggle"}
-          value={vals.toggle}
+          values={values}
           attributes={{
             type: "boolean",
             default: true,
@@ -62,7 +63,7 @@ const App = () => {
       <div style={blockStyle}>
         <ParamInput
           name={"number"}
-          value={vals.number}
+          values={values}
           attributes={{
             type: "number",
             default: 400,
@@ -74,7 +75,7 @@ const App = () => {
       <div style={blockStyle}>
         <ParamInput
           name={"range"}
-          value={vals.range}
+          values={values}
           attributes={{
             type: "number",
             default: 400,
@@ -89,7 +90,7 @@ const App = () => {
       <div style={blockStyle}>
         <ParamInput
           name={"slider"}
-          value={vals.slider}
+          values={values}
           attributes={{
             type: "number",
             default: 400,
@@ -105,7 +106,7 @@ const App = () => {
       <div style={blockStyle}>
         <ParamInput
           name={"colorHex"}
-          value={vals.colorHex}
+          values={values}
           attributes={{
             type: "color",
             model: "hex",
@@ -118,7 +119,7 @@ const App = () => {
       <div style={blockStyle}>
         <ParamInput
           name={"colorRgba"}
-          value={vals.colorRgba}
+          values={values}
           attributes={{
             type: "color",
             model: "rgba",
@@ -130,7 +131,7 @@ const App = () => {
       <div style={blockStyle}>
         <ParamInput
           name={"textOption"}
-          value={vals.textOption}
+          values={values}
           attributes={{
             type: "text",
             default: "Option 1",
@@ -143,7 +144,7 @@ const App = () => {
       <div style={blockStyle}>
         <ParamInput
           name={"numberOption"}
-          value={vals.numberOption}
+          values={values}
           attributes={{
             type: "number",
             default: 10,
@@ -156,7 +157,7 @@ const App = () => {
       <div style={blockStyle}>
         <ParamInput
           name={"objectOption"}
-          value={vals.objectOption}
+          values={values}
           attributes={{
             type: "text",
             default: "first",
@@ -167,14 +168,157 @@ const App = () => {
         />
       </div>
 
-      <h3>Buttons</h3>
+      <h3>Editable ParamInput components</h3>
 
-      <div style={blockStyle}>
-        <Button>I'm a button</Button>
+      <div style={twoBlockStyle}>
+        <ParamInput
+          name={"text"}
+          values={values}
+          attributes={{
+            type: "text",
+            default: "Hi"
+          }}
+          onChange={handleChange}
+        />
       </div>
-      <div style={blockStyle}>
-        <Toggle status={true}>Toggle On</Toggle>
-        <Toggle status={false}>Toggle Off</Toggle>
+      <div style={twoBlockStyle}>
+        <ParamInput
+          name={"text"}
+          values={values}
+          attributes={{
+            type: "text",
+            default: "Hi",
+            editable: false
+          }}
+          onChange={handleChange}
+        />
+      </div>
+      <div style={twoBlockStyle}>
+        <ParamInput
+          name={"toggle"}
+          values={values}
+          attributes={{
+            type: "boolean",
+            default: true
+          }}
+          onChange={handleChange}
+        />
+      </div>
+      <div style={twoBlockStyle}>
+        <ParamInput
+          name={"toggle"}
+          values={values}
+          attributes={{
+            type: "boolean",
+            default: true,
+            editable: false
+          }}
+          onChange={handleChange}
+        />
+      </div>
+      <div style={twoBlockStyle}>
+        <ParamInput
+          name={"number"}
+          values={values}
+          attributes={{
+            type: "number",
+            default: 400
+          }}
+          onChange={handleChange}
+        />
+      </div>
+      <div style={twoBlockStyle}>
+        <ParamInput
+          name={"number"}
+          values={values}
+          attributes={{
+            type: "number",
+            default: 400,
+            editable: false
+          }}
+          onChange={handleChange}
+        />
+      </div>
+      <div style={twoBlockStyle}>
+        <ParamInput
+          name={"slider"}
+          values={values}
+          attributes={{
+            type: "number",
+            default: 400,
+            min: -500,
+            max: 500,
+            step: 0.5,
+            slider: true
+          }}
+          onChange={handleChange}
+        />
+      </div>
+      <div style={twoBlockStyle}>
+        <ParamInput
+          name={"slider"}
+          values={values}
+          attributes={{
+            type: "number",
+            default: 400,
+            min: -500,
+            max: 500,
+            step: 0.5,
+            slider: true,
+            editable: false
+          }}
+          onChange={handleChange}
+        />
+      </div>
+      <div style={twoBlockStyle}>
+        <ParamInput
+          name={"colorHex"}
+          values={values}
+          attributes={{
+            type: "color",
+            model: "hex",
+            default: "#f62696"
+          }}
+          onChange={handleChange}
+        />
+      </div>
+      <div style={twoBlockStyle}>
+        <ParamInput
+          name={"colorHex"}
+          values={values}
+          attributes={{
+            type: "color",
+            model: "hex",
+            default: "#f62696",
+            editable: false
+          }}
+          onChange={handleChange}
+        />
+      </div>
+      <div style={twoBlockStyle}>
+        <ParamInput
+          name={"textOption"}
+          values={values}
+          attributes={{
+            type: "text",
+            default: "Option 1",
+            options: ["Option 1", "Option 2", "Option 3"]
+          }}
+          onChange={handleChange}
+        />
+      </div>
+      <div style={twoBlockStyle}>
+        <ParamInput
+          name={"textOption"}
+          values={values}
+          attributes={{
+            type: "text",
+            default: "Option 1",
+            options: ["Option 1", "Option 2", "Option 3"],
+            editable: false
+          }}
+          onChange={handleChange}
+        />
       </div>
 
       <h3>Inputs</h3>
@@ -210,6 +354,16 @@ const App = () => {
           <option>Option 2</option>
           <option>Option 3</option>
         </Select>
+      </div>
+
+      <h3>Buttons</h3>
+
+      <div style={blockStyle}>
+        <Button>I'm a button</Button>
+      </div>
+      <div style={blockStyle}>
+        <Toggle status={true}>Toggle On</Toggle>
+        <Toggle status={false}>Toggle Off</Toggle>
       </div>
     </>
   );

--- a/packages/mechanic-ui-components/src/ParamInput.js
+++ b/packages/mechanic-ui-components/src/ParamInput.js
@@ -9,11 +9,14 @@ import { OptionInput } from "./input/OptionInput.js";
 import { ColorInput } from "./input/ColorInput.js";
 import { uid } from "./uid.js";
 
-export const ParamInput = ({ name, className, value, attributes, onChange, children }) => {
+export const ParamInput = ({ name, className, values, attributes, onChange, children }) => {
   const id = useRef(uid("param-input"));
-  const { type, options, validation } = attributes;
+  const { type, options, validation, editable } = attributes;
   const _default = attributes["default"];
 
+  const value = values[name];
+  const isEditable =
+    editable === undefined ? true : typeof editable === "function" ? editable(values) : editable;
   const actualValue = value === undefined ? _default : value;
   const error = validation ? validation(actualValue) : null;
 
@@ -32,9 +35,10 @@ export const ParamInput = ({ name, className, value, attributes, onChange, child
         id={id.current}
         className={rootClasses}
         variant="mechanic-param"
-        onChange={onChange}
         invalid={error ? true : false}
-        error={error}>
+        error={error}
+        disabled={!isEditable}
+        onChange={onChange}>
         {children}
       </OptionInput>
     );
@@ -51,6 +55,7 @@ export const ParamInput = ({ name, className, value, attributes, onChange, child
         variant="mechanic-param"
         invalid={error ? true : false}
         error={error}
+        disabled={!isEditable}
         onChange={onChange}>
         {children}
       </BooleanInput>
@@ -70,6 +75,7 @@ export const ParamInput = ({ name, className, value, attributes, onChange, child
         variant="mechanic-param"
         invalid={error ? true : false}
         error={error}
+        disabled={!isEditable}
         onChange={onChange}>
         {children}
       </ColorInput>
@@ -88,6 +94,7 @@ export const ParamInput = ({ name, className, value, attributes, onChange, child
         variant="mechanic-param"
         invalid={error ? true : false}
         error={error}
+        disabled={!isEditable}
         slider={slider}
         min={min}
         max={max}
@@ -108,6 +115,7 @@ export const ParamInput = ({ name, className, value, attributes, onChange, child
       variant="mechanic-param"
       invalid={error ? true : false}
       error={error}
+      disabled={!isEditable}
       onChange={onChange}>
       {children}
     </TextInput>
@@ -123,6 +131,6 @@ ParamInput.propTypes = {
   onChange: PropTypes.func,
   name: PropTypes.string,
   className: PropTypes.string,
-  value: PropTypes.any,
+  values: PropTypes.any,
   attributes: PropTypes.object
 };

--- a/packages/mechanic-ui-components/src/ParamInput.js
+++ b/packages/mechanic-ui-components/src/ParamInput.js
@@ -16,7 +16,7 @@ export const ParamInput = ({ name, className, values, attributes, onChange, chil
 
   const value = values[name];
   const isEditable =
-    editable === undefined ? true : typeof editable === "function" ? editable(values) : editable;
+    editable === undefined ? true : typeof editable === "function" ? !!editable(values) : editable;
   const actualValue = value === undefined ? _default : value;
   const error = validation ? validation(actualValue) : null;
 

--- a/packages/mechanic-ui-components/src/buttons/Button.css
+++ b/packages/mechanic-ui-components/src/buttons/Button.css
@@ -9,7 +9,6 @@
   padding: 0.5em 1em;
 
   background-color: var(--mechanic-background);
-  cursor: pointer;
 
   font-size: inherit;
   line-height: 1em;
@@ -24,7 +23,7 @@
     cursor: pointer;
   }
 
-  &:active {
+  &:active:not([disabled]) {
     background-color: var(--mechanic-blue);
 
     color: var(--mechanic-background);
@@ -35,6 +34,7 @@
 }
 
 .disabled {
+  border: 1px solid var(--mechanic-gray);
 }
 
 .focus {

--- a/packages/mechanic-ui-components/src/buttons/Toggle.css
+++ b/packages/mechanic-ui-components/src/buttons/Toggle.css
@@ -50,6 +50,7 @@
 }
 
 .disabled {
+  border: 1px solid var(--mechanic-gray);
 }
 
 .focus {

--- a/packages/mechanic-ui-components/src/input/BooleanInput.js
+++ b/packages/mechanic-ui-components/src/input/BooleanInput.js
@@ -42,6 +42,7 @@ export const BooleanInput = props => {
         id={id}
         className={css.toggle}
         status={value}
+        disabled={disabled}
         onClick={e => onChange(e, name, !value)}
         onFocus={onFocus}
         onBlur={onBlur}

--- a/packages/mechanic-ui-components/src/input/ColorInput.js
+++ b/packages/mechanic-ui-components/src/input/ColorInput.js
@@ -61,7 +61,12 @@ export const ColorInput = props => {
         className={css.buttonContainer}
         aria-describedby={`error-${id}`}
         aria-invalid={invalid}>
-        <Button className={css.button} onClick={handleClick} onFocus={onFocus} onBlur={onBlur}>
+        <Button
+          className={css.button}
+          onClick={handleClick}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          disabled={disabled}>
           <div className={css.swatch} style={{ backgroundColor: value }} />
           <span>{value}</span>
         </Button>

--- a/packages/mechanic-ui-components/src/input/NumberInput.css
+++ b/packages/mechanic-ui-components/src/input/NumberInput.css
@@ -162,6 +162,66 @@
 }
 
 .disabled {
+  & .number-input {
+    border: 1px solid var(--mechanic-gray);
+  }
+
+  & .range-input {
+    &::-webkit-slider-thumb {
+      border: 1px solid var(--mechanic-gray);
+      cursor: default;
+    }
+
+    &::-ms-track {
+      cursor: default;
+    }
+
+    &::-moz-range-thumb {
+      border: 1px solid var(--mechanic-gray);
+      cursor: default;
+    }
+
+    &::-ms-thumb {
+      border: 1px solid var(--mechanic-gray);
+      cursor: default;
+    }
+
+    &::-webkit-slider-runnable-track {
+      border: 1px solid var(--mechanic-gray);
+      background: var(--mechanic-gray);
+      cursor: default;
+    }
+
+    &:focus::-webkit-slider-runnable-track {
+      background: var(--mechanic-gray);
+    }
+
+    &::-moz-range-track {
+      border: 1px solid var(--mechanic-gray);
+      background: var(--mechanic-gray);
+      cursor: default;
+    }
+
+    &::-ms-track {
+      border: 1px solid var(--mechanic-gray);
+      background: var(--mechanic-gray);
+      cursor: default;
+    }
+    &::-ms-fill-lower {
+      border: 1px solid var(--mechanic-gray);
+      background: var(--mechanic-gray);
+    }
+    &:focus::-ms-fill-lower {
+      background: var(--mechanic-gray);
+    }
+    &::-ms-fill-upper {
+      border: 1px solid var(--mechanic-gray);
+      background: var(--mechanic-gray);
+    }
+    &:focus::-ms-fill-upper {
+      background: var(--mechanic-gray);
+    }
+  }
 }
 
 .focus {
@@ -170,17 +230,17 @@
 .mechanic-param {
   & > .label {
     display: block;
-  
+
     margin-bottom: 0.5em;
     width: 100%;
-  
+
     font-size: 0.75em;
     font-family: var(--mechanic-param-font);
   }
 
   & > .number-input {
     width: 100%;
-    
+
     font-family: var(--mechanic-param-font);
   }
 

--- a/packages/mechanic-ui-components/src/input/NumberInput.css
+++ b/packages/mechanic-ui-components/src/input/NumberInput.css
@@ -167,7 +167,7 @@
   }
 
   & .range-wrapper {
-    color: var(--mechanic-gray);
+    color: #6d6d6d;
   }
 
   & .range-input {

--- a/packages/mechanic-ui-components/src/input/NumberInput.css
+++ b/packages/mechanic-ui-components/src/input/NumberInput.css
@@ -166,6 +166,10 @@
     border: 1px solid var(--mechanic-gray);
   }
 
+  & .range-wrapper {
+    color: var(--mechanic-gray);
+  }
+
   & .range-input {
     &::-webkit-slider-thumb {
       border: 1px solid var(--mechanic-gray);

--- a/packages/mechanic-ui-components/src/input/Select.css
+++ b/packages/mechanic-ui-components/src/input/Select.css
@@ -30,6 +30,10 @@
 }
 
 .disabled {
+  & .select {
+    border: 1px solid var(--mechanic-gray);
+    background-image: none;
+  }
 }
 
 .focus {

--- a/packages/mechanic-ui-components/src/input/TextInput.css
+++ b/packages/mechanic-ui-components/src/input/TextInput.css
@@ -19,6 +19,9 @@
 }
 
 .disabled {
+  & .input {
+    border: 1px solid var(--mechanic-gray);
+  }
 }
 
 .focus {
@@ -37,7 +40,7 @@
 
   & > .input {
     width: 100%;
-    
+
     font-family: var(--mechanic-param-font);
   }
 

--- a/packages/mechanic-ui-components/src/variables.css
+++ b/packages/mechanic-ui-components/src/variables.css
@@ -2,6 +2,7 @@
   --mechanic-text: #333;
   --mechanic-background: white;
   --mechanic-dust-gray: #f3f1f2;
+  --mechanic-gray: #aaa;
   --mechanic-black: #231f20;
   --mechanic-blue: #0f21c3;
   --mechanic-red: #f04b17;

--- a/packages/mechanic/CHANGELOG.md
+++ b/packages/mechanic/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added validation of new `"editable"` param property.
+
+### Changed
+
+- Added title to HTML of main app, title to iframe, and a label to design function select for navigation.
+- Updated prop pass for `ParamInput` components.
+
 ## [0.2.8] - 2021-07-15
 
 ### Changed

--- a/packages/mechanic/app/index.html
+++ b/packages/mechanic/app/index.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <title>Mechanic</title>
+  </head>
   <body>
     <div id="root"></div>
   </body>

--- a/packages/mechanic/app/pages/Function.js
+++ b/packages/mechanic/app/pages/Function.js
@@ -85,7 +85,7 @@ export const Function = ({ name, exports, children }) => {
               className={css.param}
               key="param-preset"
               name="preset"
-              value={values.preset}
+              values={values}
               attributes={{ type: "string", options: presets, default: presets[0] }}
               onChange={handleOnChange}
             />
@@ -94,7 +94,7 @@ export const Function = ({ name, exports, children }) => {
                 className={css.param}
                 key={`param-${name}`}
                 name={name}
-                value={values[name]}
+                values={values}
                 attributes={param}
                 onChange={handleOnChange}
               />

--- a/packages/mechanic/app/pages/Function.js
+++ b/packages/mechanic/app/pages/Function.js
@@ -135,7 +135,12 @@ export const Function = ({ name, exports, children }) => {
         </div>
       </aside>
       <main className={css.main} ref={mainRef}>
-        <iframe src="functions.html" className={css.iframe} ref={iframe} />
+        <iframe
+          title={`Design function ${name} document.`}
+          src="functions.html"
+          className={css.iframe}
+          ref={iframe}
+        />
       </main>
     </div>
   );

--- a/packages/mechanic/app/pages/Nav.css
+++ b/packages/mechanic/app/pages/Nav.css
@@ -3,11 +3,22 @@
 
   font-family: var(--mechanic-param-font);
 
+  flex-direction: column;
+}
+
+.label {
+  color: var(--mechanic-text);
+  font-size: 0.75em;
+}
+
+.selectContainer {
+  display: flex;
+
   align-items: center;
   justify-content: space-between;
 }
 
-.funclabel {
+.functionLabel {
   flex-grow: 1;
 
   font-size: 1.6em;
@@ -19,7 +30,7 @@
   border: 1px solid white;
   width: 2em;
   padding: 0.5em 0 0.5em 2em;
-  
+
   background-image: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22black%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E"),
     linear-gradient(to bottom, white 0%, white 100%);
   background-repeat: no-repeat, repeat;
@@ -29,7 +40,7 @@
   -moz-appearance: none;
   -webkit-appearance: none;
   appearance: none;
-  
+
   &:hover {
     border: 1px solid var(--mechanic-dust-gray);
   }

--- a/packages/mechanic/app/pages/Nav.js
+++ b/packages/mechanic/app/pages/Nav.js
@@ -7,19 +7,25 @@ export const Nav = ({ name, functionsNames }) => {
 
   return (
     <div className={css.root}>
-      <span className={css.funclabel}>{name}</span>
-      <select
-        className={css.navigationSelect}
-        onChange={({ target }) => history.push(target.value)}
-        name={name}
-        value={name}>
-        <option key="disabled" disabled>
-          Select...
-        </option>
-        {functionsNames.map(name => (
-          <option key={`route-${name}`}>{name}</option>
-        ))}
-      </select>
+      <label className={css.label} htmlFor="navigation-select">
+        Design Functions
+      </label>
+      <div className={css.selectContainer}>
+        <span className={css.functionLabel}>{name}</span>
+        <select
+          id="navigation-select"
+          className={css.navigationSelect}
+          onChange={({ target }) => history.push(target.value)}
+          name={name}
+          value={name}>
+          <option key="disabled" disabled>
+            Select...
+          </option>
+          {functionsNames.map(name => (
+            <option key={`route-${name}`}>{name}</option>
+          ))}
+        </select>
+      </div>
     </div>
   );
 };

--- a/packages/mechanic/src/mechanic-validation.js
+++ b/packages/mechanic/src/mechanic-validation.js
@@ -39,7 +39,16 @@ const validateParams = params => {
       return `Expected function in validation property in ${param}.`;
     }
 
-    // TODO: Add "Check that 'when' property is function"
+    // Check that 'editable' property is function
+    if (
+      hasKey(params[param], "editable") &&
+      typeof params[param].editable !== "function" &&
+      typeof params[param].editable !== "boolean"
+    ) {
+      return `Expected function or boolean in editable property in ${param}. Got ${typeof params[
+        param
+      ].editable}.`;
+    }
 
     // Check that 'options' property
     if (hasKey(params[param], "options")) {

--- a/packages/mechanic/src/mechanic-validation.js
+++ b/packages/mechanic/src/mechanic-validation.js
@@ -25,7 +25,7 @@ const validateParams = params => {
 
     // Check type is supported by Mechanic
     if (!hasKey(supportedTypes, paramType)) {
-      return `Parameter of type ${paramType} not supported, expected: ${Object.keys(
+      return `Parameter of type ${paramType} not supported, expected either: ${Object.keys(
         supportedTypes
       )}.`;
     }
@@ -49,35 +49,38 @@ const validateParams = params => {
       return `Expected function or boolean in editable property in ${paramName}. Got ${typeof param.editable}.`;
     }
 
-    // Check that 'options' property
+    // Check 'options' property
     if (hasKey(param, "options")) {
+      const { options } = param;
       // Should be function or object
-      if (!Array.isArray(param.options) && typeof param.options !== "object") {
-        return `Expected array or object in options property in ${paramName}. Got ${typeof param.options}.`;
+      if (!Array.isArray(options) && typeof options !== "object") {
+        return `Expected array or object in options property in ${paramName}. Got ${typeof options}.`;
       }
       // If it's not an array, it's an object
-      else if (!Array.isArray(param.options)) {
+      else if (!Array.isArray(options)) {
         // It should be consistent with 'default' property
-        if (!Object.keys(param.options).includes(paramDefault)) {
-          return `Default value ${paramDefault} for ${paramName} is not present in given options. `;
+        if (!Object.keys(options).includes(paramDefault)) {
+          return `Default value ${paramDefault} for ${paramName} is not present in given options: ${Object.keys(
+            options
+          )}. `;
         }
         // All values should be consistent with the param type
-        for (let option in param.options) {
-          if (typeof param.options[option] !== supportedTypes[paramType]) {
+        for (let option in options) {
+          if (typeof options[option] !== supportedTypes[paramType]) {
             return `Incorrect type of value in options object. Expected ${paramType}.`;
           }
         }
       }
       // If it's an array
-      else if (Array.isArray(param.options)) {
+      else if (Array.isArray(options)) {
         // It should be consistent with 'default' property
-        if (!param.options.includes(paramDefault)) {
-          return `Default value ${paramDefault} for ${paramName} is not present in given options. `;
+        if (!options.includes(paramDefault)) {
+          return `Default value ${paramDefault} for ${paramName} is not present in given options: ${options} `;
         }
         // All values should be consistent with the param type
-        for (let option of param.options) {
+        for (let option of options) {
           if (typeof option !== supportedTypes[paramType]) {
-            return `Incorrect type of value in options array. Expected ${paramType}.`;
+            return `Incorrect type of value ${option} (${typeof option}) in options array. Expected ${paramType}.`;
           }
         }
       }
@@ -93,33 +96,32 @@ const validateParams = params => {
  * @param {object} values - Values for some or all of the parameters
  */
 const validateValues = (params, values = {}) => {
-  for (let param in params) {
+  for (let paramName in params) {
+    const param = params[paramName];
     // Validate that values for options are specified in the template
-    if (hasKey(values, param) && hasKey(params[param], "options")) {
-      if (Array.isArray(params[param].options) && !params[param].options.includes(values[param])) {
-        return `Supplied ${param} parameter is not available in the template options: ${params[param].options}`;
-      } else if (
-        !Array.isArray(params[param].options) &&
-        !hasKey(params[param].options, values[param])
-      ) {
-        return `Supplied ${param} parameter (${
-          values[param]
-        }) is not available in the template options: ${Object.keys(params[param].options)}`;
+    if (hasKey(values, paramName) && hasKey(param, "options")) {
+      const { options } = param;
+      if (Array.isArray(options) && !options.includes(values[paramName])) {
+        return `Supplied ${paramName} parameter is not available in the template options: ${options}`;
+      } else if (!Array.isArray(options) && !hasKey(options, values[paramName])) {
+        return `Supplied ${paramName} parameter (${
+          values[paramName]
+        }) is not available in the template options: ${Object.keys(options)}`;
       }
     }
     // Run validation functions for values.
-    if (hasKey(values, param) && hasKey(params[param], "validation")) {
-      const error = params[param].validation(values[param]);
-      if (error !== null) {
-        return `Param validation error: ${error}`;
+    if (hasKey(values, paramName) && hasKey(param, "validation")) {
+      const error = param.validation(values[param]);
+      if (error !== null && error !== undefined) {
+        return `Param validation error returned: ${error}`;
       }
     }
   }
 
   // Check that there are not other values besides parameters and default params
-  for (let param in values) {
-    if (!hasKey(params, param) && !hasKey(otherParams, param)) {
-      return `Unexpected ${param} value not defined on template.`;
+  for (let paramName in values) {
+    if (!hasKey(params, paramName) && !hasKey(otherParams, paramName)) {
+      return `Unexpected ${paramName} value not defined on template.`;
     }
   }
 

--- a/packages/mechanic/src/mechanic-validation.js
+++ b/packages/mechanic/src/mechanic-validation.js
@@ -12,75 +12,72 @@ const otherParams = { preset: true, scaleToFit: true, randomSeed: true };
  */
 const validateParams = params => {
   // Check all params
-  for (let param in params) {
+  for (let paramName in params) {
+    const param = params[paramName];
+    const { type: paramType, default: paramDefault } = param;
+
     // Check for all required properties
     for (let requiredKey of requiredKeys) {
-      if (!hasKey(params[param], requiredKey)) {
-        return `Parameter ${param} must have '${requiredKey}' property.`;
+      if (!hasKey(param, requiredKey)) {
+        return `Parameter ${paramName} must have '${requiredKey}' property.`;
       }
     }
 
     // Check type is supported by Mechanic
-    if (!hasKey(supportedTypes, params[param].type)) {
-      return `Parameter of type ${params[param].type} not supported, expected: ${Object.keys(
+    if (!hasKey(supportedTypes, paramType)) {
+      return `Parameter of type ${paramType} not supported, expected: ${Object.keys(
         supportedTypes
       )}.`;
     }
 
     // Check default value is of correct type to corresponding param type
-    if (typeof params[param].default !== supportedTypes[params[param].type]) {
-      return `Default property value invalid for parameter ${param} of type ${
-        params[param].type
-      }. Expected to be ${supportedTypes[params[param].type]}.`;
+    if (typeof paramDefault !== supportedTypes[paramType]) {
+      return `Default property value invalid for parameter ${paramName} of type ${paramType}. Expected to be ${supportedTypes[paramType]}.`;
     }
 
     // Check that 'validation' property is function
-    if (hasKey(params[param], "validation") && typeof params[param].validation !== "function") {
-      return `Expected function in validation property in ${param}.`;
+    if (hasKey(param, "validation") && typeof param.validation !== "function") {
+      return `Expected function in validation property in ${paramName}. Got ${typeof param.validation}.`;
     }
 
     // Check that 'editable' property is function
     if (
-      hasKey(params[param], "editable") &&
-      typeof params[param].editable !== "function" &&
-      typeof params[param].editable !== "boolean"
+      hasKey(param, "editable") &&
+      typeof param.editable !== "function" &&
+      typeof param.editable !== "boolean"
     ) {
-      return `Expected function or boolean in editable property in ${param}. Got ${typeof params[
-        param
-      ].editable}.`;
+      return `Expected function or boolean in editable property in ${paramName}. Got ${typeof param.editable}.`;
     }
 
     // Check that 'options' property
-    if (hasKey(params[param], "options")) {
+    if (hasKey(param, "options")) {
       // Should be function or object
-      if (!Array.isArray(params[param].options) && typeof params[param].options !== "object") {
-        return `Expected array or object in options property in ${param}. Received ${typeof params[
-          param
-        ].options}`;
+      if (!Array.isArray(param.options) && typeof param.options !== "object") {
+        return `Expected array or object in options property in ${paramName}. Got ${typeof param.options}.`;
       }
       // If it's not an array, it's an object
-      else if (!Array.isArray(params[param].options)) {
+      else if (!Array.isArray(param.options)) {
         // It should be consistent with 'default' property
-        if (!Object.keys(params[param].options).includes(params[param].default)) {
-          return `Default value ${params[param].default} for ${param} is not present in given options. `;
+        if (!Object.keys(param.options).includes(paramDefault)) {
+          return `Default value ${paramDefault} for ${paramName} is not present in given options. `;
         }
         // All values should be consistent with the param type
-        for (let option in params[param].options) {
-          if (typeof params[param].options[option] !== supportedTypes[params[param].type]) {
-            return `Incorrect type of value in options object. Expected ${params[param].type}.`;
+        for (let option in param.options) {
+          if (typeof param.options[option] !== supportedTypes[paramType]) {
+            return `Incorrect type of value in options object. Expected ${paramType}.`;
           }
         }
       }
       // If it's an array
-      else if (Array.isArray(params[param].options)) {
+      else if (Array.isArray(param.options)) {
         // It should be consistent with 'default' property
-        if (!params[param].options.includes(params[param].default)) {
-          return `Default value ${params[param].default} for ${param} is not present in given options. `;
+        if (!param.options.includes(paramDefault)) {
+          return `Default value ${paramDefault} for ${paramName} is not present in given options. `;
         }
         // All values should be consistent with the param type
-        for (let option of params[param].options) {
-          if (typeof option !== supportedTypes[params[param].type]) {
-            return `Incorrect type of value in options array. Expected ${params[param].type}.`;
+        for (let option of param.options) {
+          if (typeof option !== supportedTypes[paramType]) {
+            return `Incorrect type of value in options array. Expected ${paramType}.`;
           }
         }
       }


### PR DESCRIPTION
Give parameters a way to be disabled based on current values. An "editable" field in param definition that takes a function that is evaluated on each render could be the way. This resolves #34 and its task list.

You can check how the inputs look when disabled in a comment in #34, and check some examples in `dsi-logo-maker`:

https://user-images.githubusercontent.com/13511560/126200580-b9871f2c-e301-43c8-b5e9-35a37e3945e8.mov

This PR also:
- does some validation function refactor, improving code readability and error descriptions
- fixed some of the main README typos
- fixed some small accessibility in app: added title to HTML, [title to iframe](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#accessibility_concerns), and a label to design function select for navigation:

![Screen Shot 2021-07-19 at 13 22 27](https://user-images.githubusercontent.com/13511560/126201018-0eb79424-259e-4127-9a04-136eabdfc617.png)
