### PR TITLE
Auto refresh toggle

### DIFF
--- a/packages/dsi-logo-maker/CHANGELOG.md
+++ b/packages/dsi-logo-maker/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changes
+
+- Renamed some functions presets to existing words.
+- Removed `usesRandom` setting from functions that didn't use it.
+
 ## 0.2.7 - 2021-07-13
 
 First logged release

--- a/packages/dsi-logo-maker/functions/textAnimatedCanvas/index.js
+++ b/packages/dsi-logo-maker/functions/textAnimatedCanvas/index.js
@@ -136,7 +136,7 @@ export const presets = {
     width: 500,
     ratio: 9,
   },
-  biggerr: {
+  evenBigger: {
     width: 500,
     ratio: 9,
   },

--- a/packages/dsi-logo-maker/functions/textCanvas/index.js
+++ b/packages/dsi-logo-maker/functions/textCanvas/index.js
@@ -92,7 +92,7 @@ export const presets = {
     width: 500,
     ratio: 9,
   },
-  biggerr: {
+  evenBigger: {
     width: 500,
     ratio: 9,
   },
@@ -100,5 +100,4 @@ export const presets = {
 
 export const settings = {
   engine: require("@designsystemsinternational/mechanic-engine-canvas"),
-  usesRandom: true,
 };

--- a/packages/mechanic-ui-components/CHANGELOG.md
+++ b/packages/mechanic-ui-components/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `ParamInput` component doesn't receive single `value` prop, but `values` prop with the whole object of values. This enables the `"editable"` function evaluation.
+- Tweaked flex settings for slider input to fit smaller containers.
 
 ## 0.2.7 - 2021-07-13
 

--- a/packages/mechanic-ui-components/src/input/NumberInput.css
+++ b/packages/mechanic-ui-components/src/input/NumberInput.css
@@ -34,7 +34,7 @@
 }
 
 .range-label {
-  flex: 0 0 90px;
+  flex: 0 1 90px;
 
   box-sizing: border-box;
   padding: 0 1em;
@@ -47,6 +47,7 @@
 /* https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/ */
 .range-input {
   flex: 1 1 auto;
+  min-width: 0;
 
   background: transparent; /* Otherwise white in Chrome */
 

--- a/packages/mechanic/CHANGELOG.md
+++ b/packages/mechanic/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added validation of new `"editable"` param property.
+- Adds "Auto-refresh" toggle to app that enables automatic function call when inputs are changed. It also preserves random seeds when run is automatic.
 
 ### Changed
 

--- a/packages/mechanic/app/pages/Function.css
+++ b/packages/mechanic/app/pages/Function.css
@@ -91,7 +91,7 @@
 .params {
   overflow: auto;
 
-  height: calc(100vh - 308px);
+  height: calc(100vh - 306px);
   padding-right: 30px;
 
   & > .param:first-child {

--- a/packages/mechanic/app/pages/Function.css
+++ b/packages/mechanic/app/pages/Function.css
@@ -91,7 +91,7 @@
 .params {
   overflow: auto;
 
-  height: calc(100vh - 248px);
+  height: calc(100vh - 308px);
   padding-right: 30px;
 
   & > .param:first-child {

--- a/packages/mechanic/app/pages/Function.js
+++ b/packages/mechanic/app/pages/Function.js
@@ -17,7 +17,11 @@ export const Function = ({ name, exports, children }) => {
   const iframe = useRef();
   const lastRun = useRef();
 
-  const { params, presets: exportedPresets } = exports;
+  const {
+    params,
+    presets: exportedPresets,
+    settings: { usesRandom }
+  } = exports;
   const presets = ["default"].concat(Object.keys(exportedPresets ? exportedPresets : {}));
   const canScale = !!(params.width && params.height);
   const [values, setValues] = useValues(name, params);
@@ -39,29 +43,39 @@ export const Function = ({ name, exports, children }) => {
     setValues(values => Object.assign({}, values, ...sources));
   };
 
-  const handlePreview = async () => {
+  const prepareValues = (useScale, useRandomSeed) => {
     const valuesCopy = Object.assign({}, values);
-    if (canScale && scaleToFit) {
+    if (useScale && canScale && scaleToFit) {
       const bounds = mainRef.current.getBoundingClientRect();
       valuesCopy.scaleToFit = {
         width: bounds.width - 100,
         height: bounds.height - 100
       };
     }
+    if (useRandomSeed && lastRun.current?.values) {
+      valuesCopy.randomSeed = lastRun.current.values.randomSeed;
+    }
+    return valuesCopy;
+  };
+
+  const handlePreview = async () => {
+    const valuesCopy = prepareValues(true, false);
     lastRun.current = iframe.current.contentWindow?.run?.(name, valuesCopy, true);
   };
 
-  useEffect(() => {
-    if (autoRefreshOn) handlePreview();
-  });
+  const handleAutoPreview = async () => {
+    const valuesCopy = prepareValues(true, true);
+    lastRun.current = iframe.current.contentWindow?.run?.(name, valuesCopy, true);
+  };
 
   const handleExport = async () => {
-    const valuesCopy = Object.assign({}, values);
-    if (lastRun.current?.values) {
-      valuesCopy.randomSeed = lastRun.current.values.randomSeed;
-    }
+    const valuesCopy = prepareValues(false, true);
     iframe.current.contentWindow?.run?.(name, valuesCopy);
   };
+
+  useEffect(() => {
+    if (autoRefreshOn) handleAutoPreview();
+  });
 
   // Init engine when the name of the function changes
   useEffect(() => {
@@ -135,7 +149,7 @@ export const Function = ({ name, exports, children }) => {
           <div className={css.sep} />
           <div className={classnames(css.row, css.strong)}>
             <Button className={css.grow} onClick={handlePreview} disabled={!iframeLoaded}>
-              {iframeLoaded ? "Preview" : "Loading content"}
+              {iframeLoaded ? (usesRandom ? "Preview / Randomize" : "Preview") : "Loading content"}
             </Button>
           </div>
           <div className={css.sep} />

--- a/packages/mechanic/app/pages/Function.js
+++ b/packages/mechanic/app/pages/Function.js
@@ -11,6 +11,7 @@ import css from "./Function.css";
 export const Function = ({ name, exports, children }) => {
   const [iframeLoaded, setIframeLoaded] = useState(false);
   const [scaleToFit, setScaleToFit] = useState(true);
+  const [autoRefreshOn, setAutoRefreshOn] = useState(true);
 
   const mainRef = useRef();
   const iframe = useRef();
@@ -49,6 +50,10 @@ export const Function = ({ name, exports, children }) => {
     }
     lastRun.current = iframe.current.contentWindow?.run?.(name, valuesCopy, true);
   };
+
+  useEffect(() => {
+    if (autoRefreshOn) handlePreview();
+  });
 
   const handleExport = async () => {
     const valuesCopy = Object.assign({}, values);
@@ -115,6 +120,16 @@ export const Function = ({ name, exports, children }) => {
                   ? "Scale to fit On"
                   : "Scale to fit Off"
                 : "Params missing for scaling"}
+            </Toggle>
+          </div>
+          <div className={css.sep} />
+          <div className={classnames(css.row, css.strong)}>
+            <Toggle
+              className={css.grow}
+              status={autoRefreshOn}
+              onClick={() => setAutoRefreshOn(autoRefreshOn => !autoRefreshOn)}
+              disabled={!iframeLoaded}>
+              {iframeLoaded ? "Auto-refresh" : "Loading content"}
             </Toggle>
           </div>
           <div className={css.sep} />


### PR DESCRIPTION
Adds "Auto-refresh" toggle to app that enables automatic function call when inputs are changed. It also preserves random seeds when run is automatic. This resolves #36.

For now, it just runs the design function where a previous run is done or not. So animations are just interrupted.


https://user-images.githubusercontent.com/13511560/126368301-b0f05253-2975-49ff-ac10-eb6a63384a3a.mov


This PR also tweaks styling for slider inputs and tweaks some DSI logo maker functions.
