### PR TITLE
More tweaks! Almost there!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.4] - 2021-09-13
+## [0.6.4] - 2021-09-14
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.4] - 2021-09-10
+
+### Added
+
+- Fixed anchor into App that link to feedback form.
+
+### Fixed
+
+- Changed colors in ui-components to be consistent with colors in docs
+
 ## [0.6.3] - 2021-09-10
 
 ### Fixed
@@ -120,7 +130,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 First logged release
 
-[unreleased]: https://github.com/designsystemsinternational/mechanic/compare/v0.6.3...main
+[unreleased]: https://github.com/designsystemsinternational/mechanic/compare/v0.6.4...main
+[0.6.4]: https://github.com/designsystemsinternational/mechanic/releases/tag/v0.6.4
 [0.6.3]: https://github.com/designsystemsinternational/mechanic/releases/tag/v0.6.3
 [0.6.2]: https://github.com/designsystemsinternational/mechanic/releases/tag/v0.6.2
 [0.6.1]: https://github.com/designsystemsinternational/mechanic/releases/tag/v0.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed anchor into App that link to feedback form.
 
+### Changed
+
+- Default preset is named "Custom" now
+- Preset value changes to "Custom" after value of input is changed away from current preset
+
 ### Fixed
 
 - Changed colors in ui-components to be consistent with colors in docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.4] - 2021-09-10
+## [0.6.4] - 2021-09-13
 
 ### Added
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,11 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 0.6.4 - 2021-09-13
+## 0.6.4 - 2021-09-14
 
 ### Added
 
 - Fixed anchor into App that link to feedback form.
+
+### Changed
+
+- Default preset is named "Custom" now and behaves more nicely
+
+### Fixed
+
+- Changed colors in ui-components to be consistent with colors in docs
 
 ## 0.6.3 - 2021-09-10
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.6.4 - 2021-09-10
+
+### Added
+
+- Fixed anchor into App that link to feedback form.
+
 ## 0.6.3 - 2021-09-10
 
 ### Fixed

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 0.6.4 - 2021-09-10
+## 0.6.4 - 2021-09-13
 
 ### Added
 

--- a/packages/core/app/App.js
+++ b/packages/core/app/App.js
@@ -4,6 +4,7 @@ import { Switch, Route, withRouter } from "react-router-dom";
 import { Function } from "./pages/Function.js";
 import { NotFound } from "./pages/NotFound.js";
 import { Nav } from "./pages/Nav.js";
+import Feedback from "./pages/Feedback.js";
 
 import functions from "./FUNCTIONS";
 
@@ -12,6 +13,7 @@ import * as css from "./App.module.css";
 const AppComponent = () => {
   return (
     <div className={css.root}>
+      <Feedback href="https://forms.gle/uBTn8oVThZHVghV89">Got feedback?</Feedback>
       <Switch>
         {Object.keys(functions).map((name, i) => (
           <Route

--- a/packages/core/app/pages/Feedback.js
+++ b/packages/core/app/pages/Feedback.js
@@ -1,0 +1,37 @@
+import React from "react";
+import PropTypes from "prop-types";
+import classnames from "classnames";
+import * as css from "./Feedback.module.css";
+
+export const Feedback = ({ className, href, variant, onClick, children, disabled }) => {
+  const classes = classnames(css.root, {
+    [className]: className,
+    [css[variant]]: css[variant]
+  });
+
+  return href ? (
+    <button className={classes}>
+      <a href={href} target="_blank" rel="noopener noreferrer">
+        {children}
+      </a>
+    </button>
+  ) : (
+    <button className={classes} onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  );
+};
+
+export default Feedback;
+
+Feedback.defaultProps = {
+  onClick: () => {}
+};
+
+Feedback.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  onClick: PropTypes.func,
+  variant: PropTypes.string
+};

--- a/packages/core/app/pages/Feedback.module.css
+++ b/packages/core/app/pages/Feedback.module.css
@@ -1,0 +1,36 @@
+.root {
+  position: fixed;
+  right: 0;
+  bottom: 150px;
+  z-index: 1;
+
+  -webkit-transform-origin: 100% 0;
+  -moz-transform-origin: 100% 0;
+  -ms-transform-origin: 100% 0;
+  -o-transform-origin: 100% 0;
+
+  -webkit-transform: translate(-35px) rotate(270deg);
+  -moz-transform: translate(-35px) rotate(270deg);
+  -ms-transform: translate(-35px) rotate(270deg);
+  -o-transform: translate(-35px) rotate(270deg);
+
+  padding: 0;
+  height: 35px;
+  color: currentColor;
+  border-top: 1px solid currentColor;
+  border-left: 1px solid currentColor;
+  border-right: 1px solid currentColor;
+  border-bottom: none;
+  background-color: #f7f7f7;
+  border-radius: 20px 20px 0 0;
+  font-family: inherit;
+  font-size: var(--mechanic-input-font-size);
+
+  & a {
+    color: inherit;
+    text-decoration: none;
+    font-weight: initial;
+    padding: 1em;
+    font-family: inherit;
+  }
+}

--- a/packages/core/app/pages/Feedback.module.css
+++ b/packages/core/app/pages/Feedback.module.css
@@ -4,15 +4,8 @@
   bottom: 150px;
   z-index: 1;
 
-  -webkit-transform-origin: 100% 0;
-  -moz-transform-origin: 100% 0;
-  -ms-transform-origin: 100% 0;
-  -o-transform-origin: 100% 0;
-
-  -webkit-transform: translate(-35px) rotate(270deg);
-  -moz-transform: translate(-35px) rotate(270deg);
-  -ms-transform: translate(-35px) rotate(270deg);
-  -o-transform: translate(-35px) rotate(270deg);
+  transform-origin: 100% 0;
+  transform: translate(-35px) rotate(270deg);
 
   padding: 0;
   height: 35px;

--- a/packages/core/app/pages/Feedback.module.css
+++ b/packages/core/app/pages/Feedback.module.css
@@ -7,9 +7,7 @@
   padding: 0;
   height: 45px;
   color: currentColor;
-  border-top: 1px solid currentColor;
-  border-left: 1px solid currentColor;
-  border-right: 1px solid currentColor;
+  border: 1px solid currentColor;
   border-bottom: none;
   background-color: #f7f7f7;
   border-radius: 20px 20px 0 0;

--- a/packages/core/app/pages/Feedback.module.css
+++ b/packages/core/app/pages/Feedback.module.css
@@ -4,11 +4,8 @@
   bottom: 150px;
   z-index: 1;
 
-  transform-origin: 100% 0;
-  transform: translate(-35px) rotate(270deg);
-
   padding: 0;
-  height: 35px;
+  height: 45px;
   color: currentColor;
   border-top: 1px solid currentColor;
   border-left: 1px solid currentColor;
@@ -19,11 +16,20 @@
   font-family: inherit;
   font-size: var(--mechanic-input-font-size);
 
+  transform-origin: 100% 0;
+  transform: translate(-35px) rotate(270deg);
+  transition: transform 0.25s ease;
+  &:hover {
+    transform: translate(-45px) rotate(270deg);
+  }
+
   & a {
     color: inherit;
     text-decoration: none;
     font-weight: initial;
-    padding: 1em;
     font-family: inherit;
+    display: block;
+    margin-top: -7px;
+    padding: 0em 1em;
   }
 }

--- a/packages/core/app/pages/Function.js
+++ b/packages/core/app/pages/Function.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import classnames from "classnames";
 
 import { useValues } from "./utils/useValues.js";
-import { getPossiblePresets, addPresetsAsSources } from "./utils/presets.js";
+import { getPossiblePresets, addPresetsAsSources, NO_PRESET_VALUE } from "./utils/presets.js";
 import { useShortcuts } from "./utils/useShortcuts.js";
 
 import { Button, Toggle, MechanicInput } from "@mechanic-design/ui-components";
@@ -27,8 +27,7 @@ export const Function = ({ name, exports: functionExports, children }) => {
   const canScale = !!(inputs.width && inputs.height);
   const [values, setValues] = useValues(name, inputs);
   const handleOnChange = (e, name, value) => {
-    const sources = [{ [name]: value }];
-    if (name === "preset") addPresetsAsSources(value, exportedPresets, inputs, sources);
+    const sources = addPresetsAsSources(value, name, exportedPresets, inputs, values);
     setValues(values => Object.assign({}, values, ...sources));
   };
 
@@ -90,7 +89,7 @@ export const Function = ({ name, exports: functionExports, children }) => {
             key="input-preset"
             name="preset"
             values={values}
-            attributes={{ type: "string", options: presets, default: presets[0] }}
+            attributes={{ type: "string", options: presets, default: NO_PRESET_VALUE }}
             onChange={handleOnChange}
           />
           {Object.entries(inputs).map(([name, input]) => (

--- a/packages/core/app/pages/utils/presets.js
+++ b/packages/core/app/pages/utils/presets.js
@@ -1,21 +1,31 @@
-const NO_PRESET_VALUE = "-";
-const DEFAULT_PRESET_VALUE = "default values";
+const NO_PRESET_VALUE = "Custom";
+const DEFAULT_PRESET_VALUE = "Default values";
 
 const getPossiblePresets = presets =>
   [NO_PRESET_VALUE].concat(Object.keys(presets)).concat([DEFAULT_PRESET_VALUE]);
 
-const addPresetsAsSources = (presetValue, presets, inputs, sources) => {
-  if (presetValue === DEFAULT_PRESET_VALUE) {
-    sources.push(
-      Object.entries(inputs).reduce((source, input) => {
-        if (input[1].default) source[input[0]] = input[1].default;
-        else source[input[0]] = undefined;
-        return source;
-      }, {})
-    );
-  } else if (presetValue !== NO_PRESET_VALUE) {
-    sources.push(presets[presetValue]);
+const addPresetsAsSources = (inputValue, inputName, presets, inputs, values) => {
+  const sources = [{ [inputName]: inputValue }];
+  if (inputName === "preset") {
+    if (inputValue === DEFAULT_PRESET_VALUE) {
+      sources.push(
+        Object.entries(inputs).reduce((source, input) => {
+          if (input[1].default) source[input[0]] = input[1].default;
+          else source[input[0]] = undefined;
+          return source;
+        }, {})
+      );
+    } else if (inputValue !== NO_PRESET_VALUE) {
+      sources.push(presets[inputValue]);
+    }
+  } else if (
+    values.hasOwnProperty("preset") &&
+    values.preset != NO_PRESET_VALUE &&
+    presets[values.preset].hasOwnProperty(inputName)
+  ) {
+    sources.push({ preset: NO_PRESET_VALUE });
   }
+  return sources;
 };
 
-export { getPossiblePresets, addPresetsAsSources };
+export { getPossiblePresets, addPresetsAsSources, NO_PRESET_VALUE };

--- a/packages/core/app/pages/utils/presets.js
+++ b/packages/core/app/pages/utils/presets.js
@@ -21,7 +21,7 @@ const addPresetsAsSources = (inputValue, inputName, presets, inputs, values) => 
   } else if (
     values.hasOwnProperty("preset") &&
     values.preset != NO_PRESET_VALUE &&
-    presets[values.preset].hasOwnProperty(inputName)
+    (values.preset === DEFAULT_PRESET_VALUE || presets[values.preset].hasOwnProperty(inputName))
   ) {
     sources.push({ preset: NO_PRESET_VALUE });
   }

--- a/packages/core/app/pages/utils/useValues.js
+++ b/packages/core/app/pages/utils/useValues.js
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
+import { NO_PRESET_VALUE } from "./presets.js";
 
 const copySerializable = obj => {
   if (typeof obj !== "object") {
@@ -125,7 +126,7 @@ const cleanValues = (object, reference) =>
           else current[input[0]] = undefined;
           return current;
         },
-        { preset: "" }
+        { preset: NO_PRESET_VALUE }
       );
 
 const useValues = (name, inputs) => {

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 0.6.4 - 2021-09-10
+## 0.6.4 - 2021-09-14
 
 ### Fixed
 

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.6.4 - 2021-09-10
+
+### Fixed
+
+- Changed colors in ui-components to be consistent with colors in docs
+
 ## 0.5.0 - 2021-09-06
 
 ### Changed

--- a/packages/ui-components/src/variables.css
+++ b/packages/ui-components/src/variables.css
@@ -5,8 +5,10 @@
   --mechanic-gray: #aaa;
   --mechanic-disabled: #545454;
   --mechanic-black: #231f20;
-  --mechanic-blue: #0f21c3;
-  --mechanic-red: #f04b17;
+  --mechanic-blue: #002ebb;
+  --mechanic-light-blue: #f4f7fe;
+  --mechanic-red: #e94225;
+  --mechanic-light-red: #fdd7d1;
   --mechanic-green: #21c30f;
   --mechanic-input-font-size: 1em;
   --mechanic-label-font-size: 0.75em;


### PR DESCRIPTION
This PR adds three things: 
- Adds color variables to `ui-components` and fixes red color to be consistent to docs page
- Adds a fixed anchor in the main Mechanic app that refs to the feedback Google Form we created. It's consistent visually to the one added into the documentation site. This resolves #73 
- Replaces default value for preset in UI from `"-"` to `"Custom"`. And adds input value change checkup so that whenever a preset is set and an input value linked to that preset changes, the preset input is changed to Custom. This way we don't get inconsistent states where preset is set but values don't match and preset has to be set twice to do it.

Once merged, I'll publish the latest release that contains these changes.

Some screenshots:
<img width="835" alt="Screen Shot 2021-09-13 at 10 41 59" src="https://user-images.githubusercontent.com/13511560/133094444-7e3d4005-a72e-4401-ba87-bbf02847e501.png">

https://user-images.githubusercontent.com/13511560/133094493-635d0f94-663f-461f-b04f-302766afa1af.mov


https://user-images.githubusercontent.com/13511560/133155357-8a77abe1-2e3e-465c-865c-bf6abbc0b194.mov




