### PR TITLE
Export HTMLElement in React to image and video

### DIFF
--- a/packages/core/app/pages/Function.js
+++ b/packages/core/app/pages/Function.js
@@ -34,20 +34,12 @@ export const Function = ({ name, exports: functionExports, children }) => {
 
   const prepareValues = (useScale, useRandomSeed) => {
     const valuesCopy = Object.assign({}, values);
-    valuesCopy.scaleToFit = {
-      widthOriginal: values.width,
-      heightOriginal: values.height,
-      width: values.width,
-      height: values.height,
-      factor: 1,
-    };
     if (useScale && canScale && scaleToFit) {
       const bounds = mainRef.current.getBoundingClientRect();
-      const availableWidth = bounds.width - 100
-      const availableHeight = bounds.height - 100
-      valuesCopy.scaleToFit.width = availableWidth < values.width ? availableWidth : values.width;
-      valuesCopy.scaleToFit.height = availableHeight < values.height ? availableHeight : values.height;
-      valuesCopy.scaleToFit.factor = valuesCopy.scaleToFit.width / values.width
+      valuesCopy.scaleToFit = {
+        width: bounds.width - 100,
+        height: bounds.height - 100
+      };
     }
     if (useRandomSeed && lastRun.current?.values) {
       valuesCopy.randomSeed = lastRun.current.values.randomSeed;

--- a/packages/core/app/pages/Function.js
+++ b/packages/core/app/pages/Function.js
@@ -34,17 +34,30 @@ export const Function = ({ name, exports: functionExports, children }) => {
 
   const prepareValues = (useScale, useRandomSeed) => {
     const valuesCopy = Object.assign({}, values);
+    valuesCopy.scaleToFit = {
+      widthOriginal: values.width,
+      heightOriginal: values.height,
+      width: values.width,
+      height: values.height,
+      factor: 1,
+    };
     if (useScale && canScale && scaleToFit) {
       const bounds = mainRef.current.getBoundingClientRect();
-      valuesCopy.scaleToFit = {
-        width: bounds.width - 100,
-        height: bounds.height - 100
-      };
+      const availableWidth = bounds.width - 100
+      const availableHeight = bounds.height - 100
+      valuesCopy.scaleToFit.width = availableWidth < values.width ? availableWidth : values.width;
+      valuesCopy.scaleToFit.height = availableHeight < values.height ? availableHeight : values.height;
+      valuesCopy.scaleToFit.factor = valuesCopy.scaleToFit.width / values.width
     }
     if (useRandomSeed && lastRun.current?.values) {
       valuesCopy.randomSeed = lastRun.current.values.randomSeed;
     }
     return valuesCopy;
+  };
+
+  const handleScaleToFit = () => {
+    setScaleToFit(!scaleToFit);
+    iframe.current.contentWindow?.dispatchEvent?.(new CustomEvent('scaleToFit', { detail: { scaleToFit: !scaleToFit } }));
   };
 
   const handlePreview = async () => {
@@ -111,7 +124,7 @@ export const Function = ({ name, exports: functionExports, children }) => {
             <Toggle
               status={canScale && scaleToFit}
               disabled={!canScale}
-              onClick={() => setScaleToFit(scaleToFit => !scaleToFit)}>
+              onClick={handleScaleToFit}>
               {canScale ? (scaleToFit ? "Scale to fit On" : "Scale to fit Off") : "Scale to Fit"}
             </Toggle>
             {!canScale && <span className={css.error}>Inputs missing for scaling</span>}

--- a/packages/core/app/pages/Function.js
+++ b/packages/core/app/pages/Function.js
@@ -47,11 +47,6 @@ export const Function = ({ name, exports: functionExports, children }) => {
     return valuesCopy;
   };
 
-  const handleScaleToFit = () => {
-    setScaleToFit(!scaleToFit);
-    iframe.current.contentWindow?.dispatchEvent?.(new CustomEvent('scaleToFit', { detail: { scaleToFit: !scaleToFit } }));
-  };
-
   const handlePreview = async () => {
     const valuesCopy = prepareValues(true, false);
     lastRun.current = iframe.current.contentWindow?.run?.(name, valuesCopy, true);
@@ -116,7 +111,7 @@ export const Function = ({ name, exports: functionExports, children }) => {
             <Toggle
               status={canScale && scaleToFit}
               disabled={!canScale}
-              onClick={handleScaleToFit}>
+              onClick={() => setScaleToFit(scaleToFit => !scaleToFit)}>
               {canScale ? (scaleToFit ? "Scale to fit On" : "Scale to fit Off") : "Scale to Fit"}
             </Toggle>
             {!canScale && <span className={css.error}>Inputs missing for scaling</span>}

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mechanic-design/core",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mechanic-design/core",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.14.6",
@@ -14,9 +14,9 @@
         "@babel/preset-env": "^7.14.5",
         "@babel/preset-react": "^7.14.5",
         "@babel/runtime": "^7.14.6",
-        "@mechanic-design/fonts": "^1.0.0",
-        "@mechanic-design/ui-components": "^1.0.0",
-        "@mechanic-design/utils": "^1.0.0",
+        "@mechanic-design/fonts": "^1.1.0",
+        "@mechanic-design/ui-components": "^1.1.0",
+        "@mechanic-design/utils": "^1.1.0",
         "babel-loader": "^8.2.2",
         "case": "^1.6.3",
         "classnames": "^2.2.6",
@@ -26,6 +26,7 @@
         "express": "^4.17.1",
         "fs-extra": "^10.0.0",
         "html-loader": "^2.1.2",
+        "html-to-image": "^1.9.0",
         "html-webpack-plugin": "^5.3.1",
         "loader-utils": "^2.0.0",
         "mini-css-extract-plugin": "^2.2.0",
@@ -59,15 +60,15 @@
     },
     "../fonts": {
       "name": "@mechanic-design/fonts",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT"
     },
     "../ui-components": {
       "name": "@mechanic-design/ui-components",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@mechanic-design/fonts": "^1.0.0",
+        "@mechanic-design/fonts": "^1.1.0",
         "react-color": "^2.19.3"
       },
       "devDependencies": {
@@ -121,7 +122,7 @@
     },
     "../utils": {
       "name": "@mechanic-design/utils",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.1",
@@ -4430,6 +4431,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.9.0.tgz",
+      "integrity": "sha512-9gaDCIYg62Ek07F2pBk76AHgYZ2gxq2YALU7rK3gNCqXuhu6cWzsOQqM7qGbjZiOzxGzrU1deDqZpAod2NEwbA=="
     },
     "node_modules/html-webpack-plugin": {
       "version": "5.3.2",
@@ -11406,7 +11412,7 @@
         "@babel/preset-env": "^7.14.5",
         "@babel/preset-react": "^7.14.5",
         "@babel/runtime": "^7.14.6",
-        "@mechanic-design/fonts": "^1.0.0",
+        "@mechanic-design/fonts": "^1.1.0",
         "babel-loader": "^8.2.2",
         "classnames": "^2.2.6",
         "clean-webpack-plugin": "^3.0.0",
@@ -13612,6 +13618,11 @@
       "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
       "dev": true,
       "peer": true
+    },
+    "html-to-image": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.9.0.tgz",
+      "integrity": "sha512-9gaDCIYg62Ek07F2pBk76AHgYZ2gxq2YALU7rK3gNCqXuhu6cWzsOQqM7qGbjZiOzxGzrU1deDqZpAod2NEwbA=="
     },
     "html-webpack-plugin": {
       "version": "5.3.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,6 +57,7 @@
     "express": "^4.17.1",
     "fs-extra": "^10.0.0",
     "html-loader": "^2.1.2",
+    "html-to-image": "^1.9.0",
     "html-webpack-plugin": "^5.3.1",
     "loader-utils": "^2.0.0",
     "mini-css-extract-plugin": "^2.2.0",

--- a/packages/core/src/mechanic-utils.js
+++ b/packages/core/src/mechanic-utils.js
@@ -1,5 +1,5 @@
 import { optimize, extendDefaultPlugins } from "svgo/dist/svgo.browser.js";
-import { toPng } from 'html-to-image';
+import { toPng, toCanvas } from 'html-to-image';
 
 /**
  * Appends linked styles to an SVG, returns a copy of the element
@@ -73,6 +73,18 @@ const htmlToDataUrl = async node => {
 }
 
 /**
+ * Converts a HTML node to a canvas
+ * @param {Node} node - SVG string to convert
+ */
+const htmlToCanvas = async node => {
+  return new Promise((resolve, reject) => {
+    toCanvas(node)
+      .then(resolve)
+      .catch(reject);
+  });
+}
+
+/**
  * Extracts size of an SVG element
  * @param {SVGElement} el - SVG element
  */
@@ -118,6 +130,7 @@ export {
   svgOptimize,
   svgToDataUrl,
   htmlToDataUrl,
+  htmlToCanvas,
   extractSvgSize,
   dataUrlToCanvas,
   getTimeStamp

--- a/packages/core/src/mechanic-utils.js
+++ b/packages/core/src/mechanic-utils.js
@@ -1,4 +1,5 @@
 import { optimize, extendDefaultPlugins } from "svgo/dist/svgo.browser.js";
+import { toPng } from 'html-to-image';
 
 /**
  * Appends linked styles to an SVG, returns a copy of the element
@@ -60,6 +61,18 @@ const svgToDataUrl = str => {
 };
 
 /**
+ * Converts a HTML node to a data url
+ * @param {Node} node - SVG string to convert
+ */
+const htmlToDataUrl = async node => {
+  return new Promise((resolve, reject) => {
+    toPng(node)
+      .then(resolve)
+      .catch(reject);
+  });
+}
+
+/**
  * Extracts size of an SVG element
  * @param {SVGElement} el - SVG element
  */
@@ -104,6 +117,7 @@ export {
   svgPrepare,
   svgOptimize,
   svgToDataUrl,
+  htmlToDataUrl,
   extractSvgSize,
   dataUrlToCanvas,
   getTimeStamp

--- a/packages/core/src/mechanic-validation.js
+++ b/packages/core/src/mechanic-validation.js
@@ -124,9 +124,8 @@ const validateValues = (inputs, values = {}) => {
       if (Array.isArray(options) && !options.includes(values[inputName])) {
         return `Supplied input "${inputName}" is not available in the template options: ${options}`;
       } else if (!Array.isArray(options) && !hasKey(options, values[inputName])) {
-        return `Supplied input "${inputName}" (${
-          values[inputName]
-        }) is not available in the template options: ${Object.keys(options)}`;
+        return `Supplied input "${inputName}" (${values[inputName]
+          }) is not available in the template options: ${Object.keys(options)}`;
       }
     }
     // Run validation functions for values.
@@ -219,14 +218,20 @@ const prepareValues = (inputs, settings, baseValues) => {
 const isSVG = el => el instanceof SVGElement;
 
 /**
+ * Checks whether a DOM element is instance of HTMLCanvasElement
+ * @param {object} el - A DOM element to check
+ */
+const isCanvas = el => el instanceof HTMLCanvasElement;
+
+/**
  * Validates that a DOM element is SVG or Canvas
  * @param {object} el - A DOM element to check
  */
 const validateEl = el => {
-  if (isSVG(el) || el instanceof HTMLCanvasElement) {
+  if (isSVG(el) || isCanvas(el) || el instanceof HTMLElement) {
     return null;
   }
-  return "Element passed to the frame() function must be SVGElement or HTMLCanvasElement";
+  return "Element passed to the frame() function must be SVGElement, HTMLCanvasElement or HTMLElement";
 };
 
 /**
@@ -254,6 +259,7 @@ export {
   validateSettings,
   prepareValues,
   isSVG,
+  isCanvas,
   validateEl,
   supportsFormatWebP
 };

--- a/packages/core/src/mechanic-validation.js
+++ b/packages/core/src/mechanic-validation.js
@@ -196,16 +196,24 @@ const prepareValues = (inputs, settings, baseValues) => {
     }
   });
 
-  // Scale down to fit if width and height are inputs
-  if (baseValues.scaleToFit && values.width && values.height) {
-    const ratioWidth = baseValues.scaleToFit.width ? baseValues.scaleToFit.width / values.width : 1;
-    const ratioHeight = baseValues.scaleToFit.height
-      ? baseValues.scaleToFit.height / values.height
-      : 1;
-    if (ratioWidth < 1 || ratioHeight < 1) {
-      const ratio = ratioWidth < ratioHeight ? ratioWidth : ratioHeight;
-      values.width = Math.floor(values.width * ratio);
-      values.height = Math.floor(values.height * ratio);
+  // Add ratio and original values if width and height are inputs
+  if (values.width && values.height) {
+    values.widthOriginal = values.width
+    values.heightOriginal = values.height
+    values.ratio = 1
+
+    // Calculate new width, height and ratio if scale down to fit is active
+    if (baseValues.scaleToFit) {
+      const ratioWidth = baseValues.scaleToFit.width ? baseValues.scaleToFit.width / values.width : 1;
+      const ratioHeight = baseValues.scaleToFit.height
+        ? baseValues.scaleToFit.height / values.height
+        : 1;
+      if (ratioWidth < 1 || ratioHeight < 1) {
+        const ratio = ratioWidth < ratioHeight ? ratioWidth : ratioHeight;
+        values.width = Math.floor(values.width * ratio);
+        values.height = Math.floor(values.height * ratio);
+        values.ratio = ratio
+      }
     }
   }
   return values;

--- a/packages/core/src/mechanic-validation.js
+++ b/packages/core/src/mechanic-validation.js
@@ -198,9 +198,9 @@ const prepareValues = (inputs, settings, baseValues) => {
 
   // Add ratio and original values if width and height are inputs
   if (values.width && values.height) {
-    values.widthOriginal = values.width
-    values.heightOriginal = values.height
-    values.ratio = 1
+    values._widthOriginal = values.width
+    values._heightOriginal = values.height
+    values._ratio = 1
 
     // Calculate new width, height and ratio if scale down to fit is active
     if (baseValues.scaleToFit) {
@@ -212,7 +212,7 @@ const prepareValues = (inputs, settings, baseValues) => {
         const ratio = ratioWidth < ratioHeight ? ratioWidth : ratioHeight;
         values.width = Math.floor(values.width * ratio);
         values.height = Math.floor(values.height * ratio);
-        values.ratio = ratio
+        values._ratio = ratio
       }
     }
   }
@@ -236,10 +236,10 @@ const isCanvas = el => el instanceof HTMLCanvasElement;
  * @param {object} el - A DOM element to check
  */
 const validateEl = el => {
-  if (isSVG(el) || isCanvas(el) || el instanceof HTMLElement) {
+  if (isSVG(el) || el instanceof HTMLElement) {
     return null;
   }
-  return "Element passed to the frame() function must be SVGElement, HTMLCanvasElement or HTMLElement";
+  return "Element passed to the frame() function must be SVGElement or HTMLElement";
 };
 
 /**

--- a/packages/core/src/mechanic.js
+++ b/packages/core/src/mechanic.js
@@ -40,7 +40,8 @@ export class Mechanic {
       throw new MechanicError(err3);
     }
 
-    this.inputs = inputs;
+    // this.inputs = inputs;
+    this.inputs = validation.prepareValues(inputs, settings, values);
     this.settings = settings;
     this.values = validation.prepareValues(inputs, settings, values);
   }

--- a/packages/core/src/mechanic.js
+++ b/packages/core/src/mechanic.js
@@ -40,7 +40,7 @@ export class Mechanic {
       throw new MechanicError(err3);
     }
 
-    this.inputs = validation.prepareValues(inputs, settings, values);
+    this.inputs = inputs
     this.settings = settings;
     this.values = validation.prepareValues(inputs, settings, values);
   }

--- a/packages/core/src/mechanic.js
+++ b/packages/core/src/mechanic.js
@@ -40,7 +40,6 @@ export class Mechanic {
       throw new MechanicError(err3);
     }
 
-    // this.inputs = inputs;
     this.inputs = validation.prepareValues(inputs, settings, values);
     this.settings = settings;
     this.values = validation.prepareValues(inputs, settings, values);

--- a/packages/core/src/mechanic.js
+++ b/packages/core/src/mechanic.js
@@ -40,7 +40,7 @@ export class Mechanic {
       throw new MechanicError(err3);
     }
 
-    this.inputs = inputs
+    this.inputs = inputs;
     this.settings = settings;
     this.values = validation.prepareValues(inputs, settings, values);
   }


### PR DESCRIPTION
When exporting dom-elements that use pixel values in styling, you need to account for the scale factor so the sizes of all elements look the same in both the full-size preview and the downscaled preview. Therefore I had to expose the scale ratio along with the original width and height to the handler in the 'inputs' prop, so the handler can account for that.