### PR TITLE
Fixes for number options input validation and error catching in design function execution

### DIFF
--- a/packages/core/src/base-inputs/number.js
+++ b/packages/core/src/base-inputs/number.js
@@ -21,27 +21,35 @@ export default {
   },
   requiredProperties: ["default"],
   validation: (inputValue, input) => {
-    if (typeof inputValue !== "number") {
+    if (typeof inputValue !== "number" && typeof inputValue !== "string") {
       return `Supplied input value ${inputValue} is expected to be of type "number", not ${typeof inputValue}.`;
+    } else if (typeof inputValue === "string" && Number.isNaN(parseFloat(inputValue))) {
+      return `Supplied input value ${inputValue} is unparsable string.`;
     }
+    const value = typeof inputValue === "string" ? parseFloat(inputValue) : inputValue;
     if (hasKey(input, "options")) {
       const { options } = input;
-      if (Array.isArray(options) && !options.includes(inputValue)) {
-        return `Supplied input value ${inputValue} is not available in the options: ${options}`;
-      } else if (!Array.isArray(options) && !hasKey(options, inputValue)) {
-        return `Supplied input value ${inputValue} is not available in the options: ${Object.keys(
+      if (Array.isArray(options) && !options.includes(value)) {
+        return `Supplied input value ${value} is not available in the options: ${options}`;
+      } else if (!Array.isArray(options) && !hasKey(options, value)) {
+        return `Supplied input value ${value} is not available in the options: ${Object.keys(
           options
         )}`;
       }
-    } else if (hasKey(input, "min") && inputValue < input.min) {
-      return `Supplied input value ${inputValue} is lower than minimum value: ${input.min}`;
-    } else if (hasKey(input, "max") && inputValue > input.max) {
-      return `Supplied input value ${inputValue} is greater than maximum value: ${input.min}`;
+    } else if (hasKey(input, "min") && value < input.min) {
+      return `Supplied input value ${value} is lower than minimum value: ${input.min}`;
+    } else if (hasKey(input, "max") && value > input.max) {
+      return `Supplied input value ${value} is greater than maximum value: ${input.min}`;
     }
   },
   initValue: input => input.default,
   prepareValue: (value, input) => {
-    const v = value === undefined || value === null ? input.default : value;
+    const v =
+      value === undefined || value === null
+        ? input.default
+        : typeof value === "string"
+        ? parseFloat(value)
+        : value;
     if (hasKey(input, "options")) {
       if (Array.isArray(input.options)) {
         const index = input.options.indexOf(v);

--- a/packages/core/src/base-inputs/utils.js
+++ b/packages/core/src/base-inputs/utils.js
@@ -47,7 +47,7 @@ export const getOptionsProperty = type => ({
     // If it's an array
     else if (Array.isArray(value)) {
       // It should be consistent with 'default' property
-      if (!values.includes(input.default)) {
+      if (!value.includes(input.default)) {
         return `Default value ${input.default} is not present in given options: ${value} `;
       }
       // All values should be consistent with the input type

--- a/packages/core/src/function-set-up.js
+++ b/packages/core/src/function-set-up.js
@@ -77,7 +77,10 @@ const setUp = (inputsDefs, designFunction, inputErrors) => {
         return mechanic ? mechanic : null;
       } catch (error) {
         showError(`There was an error running ${functionName} function and/or engine.`, error);
-        throw error;
+        setTimeout(() => {
+          throw error;
+        }, 0);
+        return null;
       }
     };
     console.info("Design function definition set.");
@@ -86,6 +89,7 @@ const setUp = (inputsDefs, designFunction, inputErrors) => {
       if (error instanceof MechanicInputError) {
         showError(`There was an error loading custom inputs.`, error);
       } else showError(`There was an error loading ${functionName} function and/or engine.`, error);
+      return null;
     };
     throw error;
   }


### PR DESCRIPTION
This PR fixes a couple bugs.

First, it fixes a typo in the code that validates an options input (`values` => `value`) that was noted thanks to issue #116. 

By reviewing that, I realized that validation over a number input that has options provided also would arrive to an error because the select input used returns a string and not a number, so I added some extra sentences that handles that case.

On top of that, I realized that validation over the design function's inputs showed errors correctly, but any errors that appeared when validation the values and running the design function broke the app and it's rendering. This was because the error throwing permeated into the React App and didn't just throw in the iframe. I added some return values back to the app that would correctly be received in the app, and set the error throw in a timeout so that it stays in the iframe.

If this is merged, we would release version `v2.0.0-beta.2`.