### PR TITLE
Slider input UI improvements

### DIFF
--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Updated width of number value display to `ch` units in slider so it does not overflow
+
 ## 2.0.0-beta - 2022-03-24
 
 ### Added

--- a/packages/ui-components/src/input/NumberInput.js
+++ b/packages/ui-components/src/input/NumberInput.js
@@ -62,9 +62,16 @@ export const NumberInput = props => {
   const maxDigits = useMemo(() => {
     let digits = max ? max.toString().length : 0;
     const stepParts = step ? step.toString().split(".") : [];
-    digits += stepParts[1] ? stepParts[1].length : 0;
+    // Add 1 to the decimal digits count to compensate for the decimal point
+    digits += stepParts[1] ? stepParts[1].length + 1 : 0;
     return digits;
   }, [max, step]);
+
+  // this is used to pad the value with trailing zeros
+  const decimalDigits = useMemo(() => {
+    const stepParts = step ? step.toString().split(".") : [];
+    return stepParts[1] ? stepParts[1].length : 0;
+  }, [step]);
 
   return (
     <div className={rootClasses}>
@@ -77,7 +84,7 @@ export const NumberInput = props => {
         <div className={css.rangeWrapper}>
           {value !== undefined && (
             <input
-              style={{ flexBasis: maxDigits ? `${maxDigits + 1}ch` : null }}
+              style={{ flexBasis: maxDigits ? `${maxDigits}ch` : null }}
               className={classnames(css.rangeNumberInput)}
               type={"number"}
               onChange={handleOnChange}
@@ -85,7 +92,7 @@ export const NumberInput = props => {
               max={max ? "" + max : max}
               step={step ? "" + step : step}
               name={name}
-              value={value}
+              value={value.toFixed(decimalDigits)}
             />
           )}
           <input

--- a/packages/ui-components/src/input/NumberInput.js
+++ b/packages/ui-components/src/input/NumberInput.js
@@ -77,7 +77,7 @@ export const NumberInput = props => {
         <div className={css.rangeWrapper}>
           {value !== undefined && (
             <input
-              style={{ flexBasis: maxDigits ? `${maxDigits * 0.8}em` : null }}
+              style={{ flexBasis: maxDigits ? `${maxDigits + 1}ch` : null }}
               className={classnames(css.rangeNumberInput)}
               type={"number"}
               onChange={handleOnChange}


### PR DESCRIPTION
Fixes #121 

Changes the `flex-basis` for the slider value's container from an `em` value to a `ch` value. `1ch` is measured as the width of the current font's zero, so it lends itself to be used for estimating the width of a mostly numeric string.

Also changes the value to a fixed length string based on the number of decimal digits, which makes the UI feel a little less "jumpy" when changing slider values.