### PR TITLE
Iframe URL fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-beta.8] - 2022-06-20
+
+### Added
+
+- New SVG.js image template
+- New D3 image template
+
+### Fixed
+
+- Design function iframe also takes basename to load resources, which fixes embedding Mechanic iframe into site.
+
 ## [2.0.0-beta.7] - 2022-05-16
 
 ### Fixed
@@ -272,7 +283,8 @@ Beta release
 
 First logged release
 
-[unreleased]: https://github.com/designsystemsinternational/mechanic/compare/v2.0.0-beta.7...main
+[unreleased]: https://github.com/designsystemsinternational/mechanic/compare/v2.0.0-beta.8...main
+[2.0.0-beta.8]: https://github.com/designsystemsinternational/mechanic/releases/tag/v2.0.0-beta.8
 [2.0.0-beta.7]: https://github.com/designsystemsinternational/mechanic/releases/tag/v2.0.0-beta.7
 [2.0.0-beta.6]: https://github.com/designsystemsinternational/mechanic/releases/tag/v2.0.0-beta.6
 [2.0.0-beta.5]: https://github.com/designsystemsinternational/mechanic/releases/tag/v2.0.0-beta.5

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2.0.0-beta.8 - 2022-06-20
+
+### Fixed
+
+- Design function iframe also takes basename to load resources
+
 ## 2.0.0-beta.7 - 2022-05-16
 
 ### Fixed

--- a/packages/core/app/App.js
+++ b/packages/core/app/App.js
@@ -23,7 +23,7 @@ const Layout = ({ funcName, functions, mainRef, iframeRef }) => {
       <main className={css.main} ref={mainRef}>
         <iframe
           title={`Design function ${funcName} document.`}
-          src={`/${funcName}.html`}
+          src={`${BASENAME}${funcName}.html`}
           className={css.iframe}
           ref={iframeRef}
         />

--- a/packages/create-mechanic/CHANGELOG.md
+++ b/packages/create-mechanic/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2.0.0-beta.8 - 2022-06-20
+
+### Added
+
+- New SVG.js image template
+- New D3 image template
+
 ## 2.0.0-beta.3 - 2022-03-24
 
 ### Fixed


### PR DESCRIPTION
When trying to update the embedded example in [mechanic.design](https://mechanic.design/), the build was having issues loading the nested iframe because it didn't take the subpath where the example is located into account. This PR fixes that, and also adds changelogs to publish version `v2.0.0-beta.8`.