### PR TITLE
Fixes on fixes for v2.0.0-beta.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- NPM package version shield on README
+- Docs version shield on README
+- PRs welcome shield on README
+- Added gif image header on README
+
+### Fixed
+
+- Create CLI doesn't try on it's own to use yarn if possible, it asks if try to use npm or yarn
+- Static folder gets uploaded again
+- Corrects wrong name for "slider" property of number input in their definition
+- Adds missing "multiple" property of image input in their definition
+- Tweaks size of thumbnails in image input
+- Resets cursor style on disabled image inputs
+
 ## [2.0.0-beta.8] - 2022-06-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-beta.9] - 2022-08-12
+
 ### Added
 
 - NPM package version shield on README
@@ -299,7 +301,8 @@ Beta release
 
 First logged release
 
-[unreleased]: https://github.com/designsystemsinternational/mechanic/compare/v2.0.0-beta.8...main
+[unreleased]: https://github.com/designsystemsinternational/mechanic/compare/v2.0.0-beta.9...main
+[2.0.0-beta.9]: https://github.com/designsystemsinternational/mechanic/releases/tag/v2.0.0-beta.9
 [2.0.0-beta.8]: https://github.com/designsystemsinternational/mechanic/releases/tag/v2.0.0-beta.8
 [2.0.0-beta.7]: https://github.com/designsystemsinternational/mechanic/releases/tag/v2.0.0-beta.7
 [2.0.0-beta.6]: https://github.com/designsystemsinternational/mechanic/releases/tag/v2.0.0-beta.6

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 <p align="center">
   <a href="https://mechanic.design/">
-    <img alt="Mechanic Logo" src="https://raw.githubusercontent.com/designsystemsinternational/mechanic/master/doc/logo.png" width="600"
+    <img alt="Mechanic Logo" src="https://raw.githubusercontent.com/designsystemsinternational/mechanic/main/doc/logo.gif" width="600"
     >
   </a>
 </p>
 
+![npm version](https://img.shields.io/npm/v/@mechanic-design/core.svg?style=for-the-badge&color=201ed2&labelColor=ed4600) [![Documentation](https://img.shields.io/badge/docs-v1.2.0-red.svg?style=for-the-badge&color=201ed2&labelColor=ed4600)](https://mechanic.design/) ![PRs Welcome](https://img.shields.io/badge/PRs-welcome-red.svg?style=for-the-badge&color=201ed2&labelColor=ed4600)
+
 [Mechanic](https://mechanic.design/) is a powerful design toolchain that helps forward-looking organizations move away from a manual design workflow by automating their design operations. Built with love by your friends at [Design Systems International](https://designsystems.international/).
 
-**CURRENT STATUS**: `v1.2.0` is out now! Try it and tell us what you think! `v2.0.0-beta.7` is also out and we're testing it! Feel free to test it out too!
+**CURRENT STATUS**: `v1.2.0` is out now! Try it and tell us what you think! `v2.0.0-beta.8` is also out and we're testing it! Feel free to test it out too!
 
 ## Get Started
 

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.0.0-beta.8"
+  "version": "2.0.0-beta.9"
 }

--- a/packages/cli/commands/new.js
+++ b/packages/cli/commands/new.js
@@ -98,10 +98,10 @@ const newFunctionCommand = async (argv) => {
   );
 
   // Install new dependencies
-  const install = await askToInstall(".");
+  const installation = await askToInstall(".");
 
   // Done!
-  log(content.doneAndNextStepsMessage(functionDir, install));
+  log(content.doneAndNextStepsMessage(functionDir, installation));
   log(content.bye);
 };
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mechanic-design/cli",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "description": "CLI to interact with Mechanic.",
   "license": "MIT",
   "homepage": "https://github.com/designsystemsinternational/mechanic#readme",
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@mechanic-design/utils": "^1.1.0",
-    "create-mechanic": "^2.0.0-beta.8",
+    "create-mechanic": "^2.0.0-beta.9",
     "inquirer": "^8.1.1",
     "resolve-cwd": "^3.0.0",
     "yargs": "^17.0.1"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Static folder gets uploaded again
+- Corrects wrong name for "slider" property of number input in their definition
+- Adds missing "multiple" property of image input in their definition
+
 ## 2.0.0-beta.8 - 2022-06-20
 
 ### Fixed

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2.0.0-beta.9 - 2022-08-12
+
 ### Fixed
 
 - Static folder gets uploaded again

--- a/packages/core/app/webpackConfigGenerator.cjs
+++ b/packages/core/app/webpackConfigGenerator.cjs
@@ -245,9 +245,12 @@ module.exports = function (
   );
 
   if (staticPath) {
-    new CopyPlugin({
-      patterns: [{ from: staticPath, to: staticPath }]
-    });
+    const relativeStaticPath = path.relative(process.cwd(), staticPath);
+    plugins.push(
+      new CopyPlugin({
+        patterns: [{ from: staticPath, to: relativeStaticPath }]
+      })
+    );
   }
 
   return {

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mechanic-design/core",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mechanic-design/core",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "description": "Mechanic is a framework to build assets built on web code.",
   "license": "MIT",
   "homepage": "https://github.com/designsystemsinternational/mechanic#readme",
@@ -46,7 +46,7 @@
     "@babel/preset-react": "^7.14.5",
     "@babel/runtime": "^7.14.6",
     "@mechanic-design/fonts": "^1.1.0",
-    "@mechanic-design/ui-components": "^2.0.0-beta.5",
+    "@mechanic-design/ui-components": "^2.0.0-beta.9",
     "@mechanic-design/utils": "^1.1.0",
     "babel-loader": "^8.2.2",
     "case": "^1.6.3",

--- a/packages/core/src/base-inputs/image.js
+++ b/packages/core/src/base-inputs/image.js
@@ -5,7 +5,8 @@ export default {
   properties: {
     validation: validationProperty,
     editable: editableProperty,
-    label: getTypeValidationProperty("label", "string")
+    label: getTypeValidationProperty("label", "string"),
+    multiple: getTypeValidationProperty("multiple", "boolean")
   },
   requiredProperties: [],
   validation: () => null,

--- a/packages/core/src/base-inputs/number.js
+++ b/packages/core/src/base-inputs/number.js
@@ -17,7 +17,7 @@ export default {
     min: getTypeValidationProperty("min", "number"),
     max: getTypeValidationProperty("max", "number"),
     step: getTypeValidationProperty("step", "number"),
-    range: getTypeValidationProperty("range", "boolean")
+    slider: getTypeValidationProperty("slider", "boolean")
   },
   requiredProperties: ["default"],
   validation: (inputValue, input) => {

--- a/packages/create-mechanic/CHANGELOG.md
+++ b/packages/create-mechanic/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2.0.0-beta.9 - 2022-08-12
+
 ### Fixed
 
 - Create CLI doesn't try on it's own to use yarn if possible, it asks if try to use npm or yarn

--- a/packages/create-mechanic/CHANGELOG.md
+++ b/packages/create-mechanic/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Create CLI doesn't try on it's own to use yarn if possible, it asks if try to use npm or yarn
+
 ## 2.0.0-beta.8 - 2022-06-20
 
 ### Added

--- a/packages/create-mechanic/function-examples/business-card-generator/dependencies.json
+++ b/packages/create-mechanic/function-examples/business-card-generator/dependencies.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@mechanic-design/engine-react": "^2.0.0-beta.8"
+    "@mechanic-design/engine-react": "^2.0.0-beta.9"
   }
 }

--- a/packages/create-mechanic/function-examples/instagram-story-generator/dependencies.json
+++ b/packages/create-mechanic/function-examples/instagram-story-generator/dependencies.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@mechanic-design/engine-react": "^2.0.0-beta.8"
+    "@mechanic-design/engine-react": "^2.0.0-beta.9"
   }
 }

--- a/packages/create-mechanic/function-examples/poster-generator/dependencies.json
+++ b/packages/create-mechanic/function-examples/poster-generator/dependencies.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@mechanic-design/engine-p5": "^2.0.0-beta.8"
+    "@mechanic-design/engine-p5": "^2.0.0-beta.9"
   }
 }

--- a/packages/create-mechanic/function-templates/canvas-image/dependencies.json
+++ b/packages/create-mechanic/function-templates/canvas-image/dependencies.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@mechanic-design/engine-canvas": "^2.0.0-beta.8"
+    "@mechanic-design/engine-canvas": "^2.0.0-beta.9"
   }
 }

--- a/packages/create-mechanic/function-templates/canvas-video/dependencies.json
+++ b/packages/create-mechanic/function-templates/canvas-video/dependencies.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@mechanic-design/engine-canvas": "^2.0.0-beta.8"
+    "@mechanic-design/engine-canvas": "^2.0.0-beta.9"
   }
 }

--- a/packages/create-mechanic/function-templates/d3-image/dependencies.json
+++ b/packages/create-mechanic/function-templates/d3-image/dependencies.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@mechanic-design/engine-svg": "^2.0.0-beta.8",
+    "@mechanic-design/engine-svg": "^2.0.0-beta.9",
     "d3": "^7.4.4"
   }
 }

--- a/packages/create-mechanic/function-templates/p5-image/dependencies.json
+++ b/packages/create-mechanic/function-templates/p5-image/dependencies.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@mechanic-design/engine-p5": "^2.0.0-beta.8"
+    "@mechanic-design/engine-p5": "^2.0.0-beta.9"
   }
 }

--- a/packages/create-mechanic/function-templates/p5-video/dependencies.json
+++ b/packages/create-mechanic/function-templates/p5-video/dependencies.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@mechanic-design/engine-p5": "^2.0.0-beta.8"
+    "@mechanic-design/engine-p5": "^2.0.0-beta.9"
   }
 }

--- a/packages/create-mechanic/function-templates/react-image/dependencies.json
+++ b/packages/create-mechanic/function-templates/react-image/dependencies.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@mechanic-design/engine-react": "^2.0.0-beta.8"
+    "@mechanic-design/engine-react": "^2.0.0-beta.9"
   }
 }

--- a/packages/create-mechanic/function-templates/react-video/dependencies.json
+++ b/packages/create-mechanic/function-templates/react-video/dependencies.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@mechanic-design/engine-react": "^2.0.0-beta.8"
+    "@mechanic-design/engine-react": "^2.0.0-beta.9"
   }
 }

--- a/packages/create-mechanic/function-templates/svg-image/dependencies.json
+++ b/packages/create-mechanic/function-templates/svg-image/dependencies.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@mechanic-design/engine-svg": "^2.0.0-beta.8"
+    "@mechanic-design/engine-svg": "^2.0.0-beta.9"
   }
 }

--- a/packages/create-mechanic/function-templates/svg-video/dependencies.json
+++ b/packages/create-mechanic/function-templates/svg-video/dependencies.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@mechanic-design/engine-svg": "^2.0.0-beta.8"
+    "@mechanic-design/engine-svg": "^2.0.0-beta.9"
   }
 }

--- a/packages/create-mechanic/function-templates/svgjs-image/dependencies.json
+++ b/packages/create-mechanic/function-templates/svgjs-image/dependencies.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@mechanic-design/engine-svg": "^2.0.0-beta.8",
+    "@mechanic-design/engine-svg": "^2.0.0-beta.9",
     "@svgdotjs/svg.js": "^3.1.2"
   }
 }

--- a/packages/create-mechanic/index.js
+++ b/packages/create-mechanic/index.js
@@ -9,8 +9,10 @@ const {
   getProjectQuestion,
   confirmDFQuestion,
   confirmInstallQuestion,
+  installationMethodQuestion,
   generateProjectTemplate,
   installDependencies,
+  checkLockFile,
 } = require("./new-project");
 const {
   baseExists,
@@ -29,8 +31,17 @@ const askToInstall = async (projectName) => {
   // Install dependencies in new project directory
   const { install } = await inquirer.prompt(confirmInstallQuestion);
   await sleep();
+
   if (install) {
-    await installDependencies(projectName);
+    let installingMethod = await checkLockFile(projectName);
+    if (!installingMethod) {
+      installingMethod = (await inquirer.prompt(installationMethodQuestion))
+        .installingMethod;
+      await sleep();
+    }
+
+    const success = await installDependencies(projectName, installingMethod);
+    return { success, installingMethod };
   }
   return install;
 };

--- a/packages/create-mechanic/package.json
+++ b/packages/create-mechanic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-mechanic",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "description": "Create Mechanic projects.",
   "license": "MIT",
   "homepage": "https://github.com/designsystemsinternational/mechanic#readme",

--- a/packages/create-mechanic/project-template/package.json
+++ b/packages/create-mechanic/project-template/package.json
@@ -7,7 +7,7 @@
     "new": "mechanic new function"
   },
   "devDependencies": {
-    "@mechanic-design/core": "^2.0.0-beta.8",
-    "@mechanic-design/cli": "^2.0.0-beta.8"
+    "@mechanic-design/core": "^2.0.0-beta.9",
+    "@mechanic-design/cli": "^2.0.0-beta.9"
   }
 }

--- a/packages/create-mechanic/script-content.js
+++ b/packages/create-mechanic/script-content.js
@@ -94,19 +94,27 @@ ${bgBlue(
 
   confirmInstallQuestion:
     "Do you wish to install dependencies for your project right away?",
+  installationMethodQuestion:
+    "Do you wish to install dependencies using npm or yarn?",
   installTry: (method) => `Trying with ${method}.`,
   installSucceed: (method) => `Installed dependencies with ${method}.`,
-  installFailed: (method) => `Failed to install with ${method}.`,
-  installFail:
-    "Failed to install with npm. Try installing by yourself to check the issue.",
-
-  doneAndNextStepsMessage: (
-    projectName,
-    installed
-  ) => `\nDone! Mechanic project created at ${success(projectName)}
+  installFailed: (method) =>
+    `Failed to install with ${method}. Try installing by yourself to check the issue.`,
+  doneAndNextStepsMessage: (projectName, installation) => `
+Done! Mechanic project created at ${success(projectName)}
 To start you now can run:
-> \`cd ${projectName}\`${installed ? "" : "\n> `npm i`"}
-> \`npm run dev\`
+> \`cd ${projectName}\`${
+    !installation
+      ? "\n> `npm install` or `yarn install`"
+      : !installation.success
+      ? `\n> \`${installation.installingMethod} install\``
+      : ""
+  }
+> ${
+    !installation
+      ? "\n> `npm run dev` or `yarn run dev`"
+      : `\`${installation.installingMethod} run dev\``
+  }
 `,
   bye: mechanicInverse,
 
@@ -116,11 +124,19 @@ To start you now can run:
   notMechanicProjectError: `Not mechanic project: new function can only be run inside mechanic project.
   Either the current working directory does not contain a valid package.json or '${mechanicPackage}' is not specified as a dependency`,
 
-  newFunctionNextStepsMessage: (
-    functionDir,
-    installed
-  ) => `Done! Design function created at ${success(functionDir)}
-To start you now can run:${installed ? "" : "\n> `npm i`"}
-> \`npm run dev\`
+  newFunctionNextStepsMessage: (functionDir, installation) => `
+Done! Design function created at ${success(functionDir)}
+To start you now can run:${
+    !installation
+      ? "\n> `npm install` or `yarn install`"
+      : !installation.success
+      ? `\n> \`${installation.installingMethod} install\``
+      : ""
+  }
+> ${
+    !installation
+      ? "\n> `npm run dev` or `yarn run dev`"
+      : `\`${installation.installingMethod} run dev\``
+  }
   `,
 };

--- a/packages/dsi-logo-maker/package-lock.json
+++ b/packages/dsi-logo-maker/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mechanic-design/dsi-logo-maker",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/dsi-logo-maker/package.json
+++ b/packages/dsi-logo-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mechanic-design/dsi-logo-maker",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "description": "DSI Logo Maker based on Mechanic.",
   "license": "MIT",
   "homepage": "https://github.com/designsystemsinternational/mechanic#readme",
@@ -37,10 +37,10 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.14.6",
-    "@mechanic-design/cli": "^2.0.0-beta.8",
-    "@mechanic-design/core": "^2.0.0-beta.8",
-    "@mechanic-design/engine-canvas": "^2.0.0-beta.8",
-    "@mechanic-design/engine-react": "^2.0.0-beta.8"
+    "@mechanic-design/cli": "^2.0.0-beta.9",
+    "@mechanic-design/core": "^2.0.0-beta.9",
+    "@mechanic-design/engine-canvas": "^2.0.0-beta.9",
+    "@mechanic-design/engine-react": "^2.0.0-beta.9"
   },
   "private": true,
   "gitHead": "72540367e35f7c65bc111779ceb4c59ea0e1a5fb"

--- a/packages/engine-canvas/package.json
+++ b/packages/engine-canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mechanic-design/engine-canvas",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "description": "Mechanic engine that powers the Canvas API.",
   "license": "MIT",
   "homepage": "https://github.com/designsystemsinternational/mechanic#readme",
@@ -36,7 +36,7 @@
   "type": "module",
   "exports": "./index.js",
   "dependencies": {
-    "@mechanic-design/core": "^2.0.0-beta.8"
+    "@mechanic-design/core": "^2.0.0-beta.9"
   },
   "engines": {
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"

--- a/packages/engine-p5/package.json
+++ b/packages/engine-p5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mechanic-design/engine-p5",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "description": "Mechanic engine that powers p5.js.",
   "license": "MIT",
   "homepage": "https://github.com/designsystemsinternational/mechanic#readme",
@@ -36,7 +36,7 @@
   "type": "module",
   "exports": "./index.js",
   "dependencies": {
-    "@mechanic-design/core": "^2.0.0-beta.8",
+    "@mechanic-design/core": "^2.0.0-beta.9",
     "p5": "^1.4.0"
   },
   "engines": {

--- a/packages/engine-react/package.json
+++ b/packages/engine-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mechanic-design/engine-react",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "description": "Mechanic engine that powers React SVG declaration.",
   "license": "MIT",
   "homepage": "https://github.com/designsystemsinternational/mechanic#readme",
@@ -40,7 +40,7 @@
     "react-dom": "^17.0.2"
   },
   "dependencies": {
-    "@mechanic-design/core": "^2.0.0-beta.8"
+    "@mechanic-design/core": "^2.0.0-beta.9"
   },
   "engines": {
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"

--- a/packages/engine-svg/package.json
+++ b/packages/engine-svg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mechanic-design/engine-svg",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "description": "Mechanic engine that powers string SVG usage.",
   "license": "MIT",
   "homepage": "https://github.com/designsystemsinternational/mechanic#readme",
@@ -33,7 +33,7 @@
   "type": "module",
   "exports": "./index.js",
   "dependencies": {
-    "@mechanic-design/core": "^2.0.0-beta.8"
+    "@mechanic-design/core": "^2.0.0-beta.9"
   },
   "engines": {
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2.0.0-beta.9 - 2022-08-12
+
 ### Fixed
 
 - Tweaks size of thumbnails in image input

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Tweaks size of thumbnails in image input
+- Resets cursor style on disabled image inputs
+
 ## 2.0.0-beta.4 - 2022-04-14
 
 ### Fixed

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mechanic-design/ui-components",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.9",
   "description": "UI component library for Mechanic's app.",
   "license": "MIT",
   "homepage": "https://github.com/designsystemsinternational/mechanic#readme",

--- a/packages/ui-components/src/input/ImageInput.module.css
+++ b/packages/ui-components/src/input/ImageInput.module.css
@@ -39,7 +39,8 @@
 }
 
 .thumbnail {
-  height: var(--mechanic-input-height-half);
+  max-height: var(--mechanic-input-height-half); /* new */
+  max-width: 150px;  /* new */
   border-radius: 3px;
 }
 
@@ -101,6 +102,10 @@
 
 .disabled {
   opacity: 0.4;
+}
+
+.disabled .browseButton {
+  cursor: default;
 }
 
 .container:not([disabled]):hover {

--- a/packages/ui-components/src/input/ImageInput.module.css
+++ b/packages/ui-components/src/input/ImageInput.module.css
@@ -39,8 +39,8 @@
 }
 
 .thumbnail {
-  max-height: var(--mechanic-input-height-half); /* new */
-  max-width: 150px;  /* new */
+  max-height: var(--mechanic-input-height-half);
+  max-width: 150px;
   border-radius: 3px;
 }
 


### PR DESCRIPTION

### Added

- NPM package version shield on main README
- Docs version shield on main README
- PRs welcome shield on main README
- Added gif image header on main README

### Fixed

- Create CLI doesn't try on it's own to use yarn if possible, it asks if try to use npm or yarn
- Static folder gets uploaded again (I broke it in previous fix, ups)
- Corrects wrong name for "slider" property of number input in their definition
- Adds missing "multiple" property of image input in their definition
- Tweaks size of thumbnails in image input
- Resets cursor style on disabled image inputs