### PR TITLE
Input storage sort hash

### DIFF
--- a/packages/core/app/components/SideBar.js
+++ b/packages/core/app/components/SideBar.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import cn from "classnames";
 
 import { useIframeLoaded } from "./utils/useIframeLoaded.js";
-import { useValues, clearLocalStorage } from "./utils/useValues.js";
+import { useValues } from "./utils/useValues.js";
 import { getPossiblePresets, NO_PRESET_VALUE } from "./utils/presets.js";
 import { useShortcuts } from "./utils/useShortcuts.js";
 import { useSeedHistory } from "./utils/useSeedHistory.js";

--- a/packages/core/app/components/SideBar.js
+++ b/packages/core/app/components/SideBar.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import cn from "classnames";
 
 import { useIframeLoaded } from "./utils/useIframeLoaded.js";
-import { useValues } from "./utils/useValues.js";
+import { useValues, clearLocalStorage } from "./utils/useValues.js";
 import { getPossiblePresets, NO_PRESET_VALUE } from "./utils/presets.js";
 import { useShortcuts } from "./utils/useShortcuts.js";
 import { useSeedHistory } from "./utils/useSeedHistory.js";

--- a/packages/core/app/components/utils/useSeedHistory.js
+++ b/packages/core/app/components/utils/useSeedHistory.js
@@ -96,7 +96,7 @@ function undoReducer(state, action) {
 const getNewSeed = () => seedrandom(null, { pass: (_, seed) => ({ seed }) }).seed;
 
 export function useSeedHistory(functionName) {
-  const key = `--${functionName}-seed`;
+  const key = `mechanic_seed_${functionName}`;
   const [state, dispatch] = useReducer(
     undoReducer,
     initialize(key, {

--- a/packages/core/app/components/utils/useValues.js
+++ b/packages/core/app/components/utils/useValues.js
@@ -135,18 +135,6 @@ function useLocalStorageState(key, initialState, clean) {
   return [value, setValue, remove];
 }
 
-function clearLocalStorage() {
-  if (typeof localStorage === "undefined") {
-    return null;
-  }
-  for (let i = 0; i < localStorage.length; i++) {
-    const key = localStorage.key(i);
-    if (key.startsWith("mechanic_")) {
-      localStorage.removeItem(key);
-    }
-  }
-}
-
 const cleanValues = (object, reference) => {
   for (let property in object) {
     if (!(property in reference) && property !== "preset") {

--- a/packages/core/app/components/utils/useValues.js
+++ b/packages/core/app/components/utils/useValues.js
@@ -195,4 +195,4 @@ const useValues = (functionName, functionInputs, presets) => {
   return [values, setValues];
 };
 
-export { useValues, clearLocalStorage };
+export { useValues };

--- a/packages/core/app/components/utils/useValues.js
+++ b/packages/core/app/components/utils/useValues.js
@@ -135,6 +135,18 @@ function useLocalStorageState(key, initialState, clean) {
   return [value, setValue, remove];
 }
 
+function clearLocalStorage() {
+  if (typeof localStorage === "undefined") {
+    return null;
+  }
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key.startsWith("mechanic_")) {
+      localStorage.removeItem(key);
+    }
+  }
+}
+
 const cleanValues = (object, reference) => {
   for (let property in object) {
     if (!(property in reference) && property !== "preset") {
@@ -177,9 +189,9 @@ const useValues = (functionName, functionInputs, presets) => {
   }, [functionInputs]);
 
   const inputsHash = generateHashFromInputsObject(functionInputs);
-  const storageKey = `df_${functionName}_${inputsHash}`;
+  const storageKey = `mechanic_df_${functionName}_${inputsHash}`;
 
-  const [values, __setValues] = useLocalStorageState(`df_${storageKey}`, initialValue, clean);
+  const [values, __setValues] = useLocalStorageState(storageKey, initialValue, clean);
 
   const setValues = (name, value) => {
     __setValues(draft => {
@@ -195,4 +207,4 @@ const useValues = (functionName, functionInputs, presets) => {
   return [values, setValues];
 };
 
-export { useValues };
+export { useValues, clearLocalStorage };

--- a/packages/core/app/components/utils/useValues.js
+++ b/packages/core/app/components/utils/useValues.js
@@ -23,7 +23,9 @@ const copySerializable = obj => {
     }
   } else {
     copy = {};
-    for (const key in obj) {
+    const keys = Object.keys(obj);
+    keys.sort();
+    for (const key of keys) {
       if (isSerializable(obj[key])) {
         copy[key] = copySerializable(obj[key]);
       } else console.warn("Unserializable object ignored for local storage persistance.");


### PR DESCRIPTION
The tweak introduced here is adding key sorting to the key hash generation for input storage. Since the hash is computed from a string representation of a copy of the inputs export object, the order of the keys become important to generate the hash. This made the updated setup (introduced in https://github.com/designsystemsinternational/mechanic/pull/140) create a new storage even when changing the order of keys in the input, or even keys inside the values for inputs, which should (I think) preserve the storage for that definition.