### PR TITLE
fix: add property sorting for storage hashing

### DIFF
--- a/packages/core/app/components/utils/useValues.js
+++ b/packages/core/app/components/utils/useValues.js
@@ -23,7 +23,9 @@ const copySerializable = obj => {
     }
   } else {
     copy = {};
-    for (const key in obj) {
+    const keys = Object.keys(obj);
+    keys.sort();
+    for (const key of keys) {
       if (isSerializable(obj[key])) {
         copy[key] = copySerializable(obj[key]);
       } else console.warn("Unserializable object ignored for local storage persistance.");
@@ -175,9 +177,9 @@ const useValues = (functionName, functionInputs, presets) => {
   }, [functionInputs]);
 
   const inputsHash = generateHashFromInputsObject(functionInputs);
-  const storageKey = `df_${functionName}_${inputsHash}`;
+  const storageKey = `mechanic_df_${functionName}_${inputsHash}`;
 
-  const [values, __setValues] = useLocalStorageState(`df_${storageKey}`, initialValue, clean);
+  const [values, __setValues] = useLocalStorageState(storageKey, initialValue, clean);
 
   const setValues = (name, value) => {
     __setValues(draft => {


### PR DESCRIPTION
The tweak introduced here is adding key sorting to the key hash generation for input storage. Since the hash is computed from a string representation of a copy of the inputs export object, the order of the keys become important to generate the hash. This made the updated setup (introduced in https://github.com/designsystemsinternational/mechanic/pull/140) create a new storage even when changing the order of keys in the input, or even keys inside the values for inputs, which should (I think) preserve the storage for that definition.