### PR TITLE
Discussion: adds local storage clearing

### DIFF
--- a/packages/core/app/components/utils/useSeedHistory.js
+++ b/packages/core/app/components/utils/useSeedHistory.js
@@ -96,7 +96,7 @@ function undoReducer(state, action) {
 const getNewSeed = () => seedrandom(null, { pass: (_, seed) => ({ seed }) }).seed;
 
 export function useSeedHistory(functionName) {
-  const key = `--${functionName}-seed`;
+  const key = `mechanic_seed_${functionName}`;
   const [state, dispatch] = useReducer(
     undoReducer,
     initialize(key, {

--- a/packages/core/app/components/utils/useValues.js
+++ b/packages/core/app/components/utils/useValues.js
@@ -135,6 +135,18 @@ function useLocalStorageState(key, initialState, clean) {
   return [value, setValue, remove];
 }
 
+function clearLocalStorage() {
+  if (typeof localStorage === "undefined") {
+    return null;
+  }
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key.startsWith("mechanic_")) {
+      localStorage.removeItem(key);
+    }
+  }
+}
+
 const cleanValues = (object, reference) => {
   for (let property in object) {
     if (!(property in reference) && property !== "preset") {
@@ -195,4 +207,4 @@ const useValues = (functionName, functionInputs, presets) => {
   return [values, setValues];
 };
 
-export { useValues };
+export { useValues, clearLocalStorage };


### PR DESCRIPTION
Moving a conversation started in  #150 here:

One thing that worried me about the #140 was that it maybe resets values for the inputs too frequently, even if it's not needed in certain scenarios. Like maybe an number input value I tweaked into a very specific value already in the UI, but if I tweak the max value in the definition it will reset the current value. But of course, what if that max value is smaller than the current value? There may be a lot of edge cases that are weird to control, but at some point we could introduce smarter resets. The current setup is simpler in that sense.

But another thing I worry it introduces is adding much more new entries in local storage. I started worrying back when we introduced seed history storage, cause this too already seems like a lot saved there. So here I also add a little clearLocalStorage function that could be called from the UI in certain scenarios (like debugging or something crashes and we add to the error log that they can clear it). Tho I don't know yet how or where to add that in the UI. Any ideas welcome :)


Lucas thoughts:

I'm just leaving some initial ideas here:

- I'm not sure how much of an issue too many local storage entries are performance wise, but maybe a simple heuristic to clean up could be keep track of the current local storage key. If the key gets changed (because the inputs change) we could just delete the current key, before setting current key to the new key
  - I also like your idea of adding a UI option as this might be the more explicit solution
- I think localStorage is stored on hard drive, so maybe there's a minor performance gain in debouncing localStorage writes?
- I would like to brainstorm if there could be a simple heuristic of when to reset the cache key and when to keep the old one without things becoming too complex. Maybe we could also avoid resetting all values to their default by merging the contents of the previous local storage cache with the new local storage. This could maybe be done fairly simple (if nothing about the input was changed -> copy the old value, if something about the input was changed -> reset the value to default)
