### PR TITLE
159 number input improvements

### DIFF
--- a/packages/core/app/components/Input.js
+++ b/packages/core/app/components/Input.js
@@ -11,7 +11,8 @@ import {
 } from "@mechanic-design/ui-components";
 import { customComponents } from "../INPUTS";
 
-const uid = (prefix = "comp") => prefix + "-" + Math.random().toString(36).substring(2, 16);
+const uid = (prefix = "comp") =>
+  prefix + "-" + Math.random().toString(36).substring(2, 16);
 
 const baseComponents = {
   text: props => {
@@ -28,7 +29,9 @@ const baseComponents = {
     if (options) {
       return <OptionInput {...props} options={options} />;
     }
-    return <NumberInput min={min} max={max} step={step} slider={slider} {...props} />;
+    return (
+      <NumberInput min={min} max={max} step={step} slider={slider} {...props} />
+    );
   },
   boolean: props => <BooleanInput {...props} />,
   color: props => {
@@ -46,7 +49,14 @@ const baseComponents = {
   }
 };
 
-export const Input = ({ name, className, values, inputDef, onChange, children }) => {
+export const Input = ({
+  name,
+  className,
+  values,
+  inputDef,
+  onChange,
+  children
+}) => {
   const id = useRef(uid("mechanic-input"));
   const { type } = inputDef;
   if (type in customComponents) {
@@ -71,7 +81,11 @@ export const Input = ({ name, className, values, inputDef, onChange, children })
 
   const value = values[name];
   const isEditable =
-    editable === undefined ? true : typeof editable === "function" ? !!editable(values) : editable;
+    editable === undefined
+      ? true
+      : typeof editable === "function"
+      ? !!editable(values)
+      : editable;
   const actualValue = value === undefined ? _default : value;
   const error = validation ? validation(values) : null;
 
@@ -89,7 +103,8 @@ export const Input = ({ name, className, values, inputDef, onChange, children })
       error={error}
       disabled={!isEditable}
       onChange={onChange}
-      inputDef={inputDef}>
+      inputDef={inputDef}
+    >
       {children}
     </Component>
   );

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Keeping Shift pressed will cause the arrow steps to be 10x the size of step on number inputs.
+- Number input allows you to type a value that is out of min/max range. It will not emit this value, so an invalid value won't cause a re-render.
+
 ## 2.0.0-beta.9 - 2022-08-12
 
 ### Fixed

--- a/packages/ui-components/src/MechanicInput.js
+++ b/packages/ui-components/src/MechanicInput.js
@@ -11,7 +11,14 @@ import { ColorInput } from "./input/ColorInput.js";
 import { ImageInput } from "./input/ImageInput.js";
 import { uid } from "./uid.js";
 
-export const MechanicInput = ({ name, className, values, attributes, onChange, children }) => {
+export const MechanicInput = ({
+  name,
+  className,
+  values,
+  attributes,
+  onChange,
+  children
+}) => {
   const id = useRef(uid("mechanic-input"));
   const { type, label: _label, options, validation, editable } = attributes;
   const _default = attributes["default"];
@@ -19,7 +26,11 @@ export const MechanicInput = ({ name, className, values, attributes, onChange, c
 
   const value = values[name];
   const isEditable =
-    editable === undefined ? true : typeof editable === "function" ? !!editable(values) : editable;
+    editable === undefined
+      ? true
+      : typeof editable === "function"
+      ? !!editable(values)
+      : editable;
   const actualValue = value === undefined ? _default : value;
   const error = validation ? validation(actualValue) : null;
 
@@ -40,7 +51,8 @@ export const MechanicInput = ({ name, className, values, attributes, onChange, c
         invalid={error ? true : false}
         error={error}
         disabled={!isEditable}
-        onChange={onChange}>
+        onChange={onChange}
+      >
         {children}
       </OptionInput>
     );
@@ -59,7 +71,8 @@ export const MechanicInput = ({ name, className, values, attributes, onChange, c
         error={error}
         multiple={multiple}
         disabled={!isEditable}
-        onChange={onChange}>
+        onChange={onChange}
+      >
         {children}
       </ImageInput>
     );
@@ -76,7 +89,8 @@ export const MechanicInput = ({ name, className, values, attributes, onChange, c
         invalid={error ? true : false}
         error={error}
         disabled={!isEditable}
-        onChange={onChange}>
+        onChange={onChange}
+      >
         {children}
       </BooleanInput>
     );
@@ -95,7 +109,8 @@ export const MechanicInput = ({ name, className, values, attributes, onChange, c
         invalid={error ? true : false}
         error={error}
         disabled={!isEditable}
-        onChange={onChange}>
+        onChange={onChange}
+      >
         {children}
       </ColorInput>
     );
@@ -103,6 +118,7 @@ export const MechanicInput = ({ name, className, values, attributes, onChange, c
 
   if (type === "number") {
     const { min, max, step, slider } = attributes;
+
     return (
       <NumberInput
         label={label}
@@ -117,7 +133,8 @@ export const MechanicInput = ({ name, className, values, attributes, onChange, c
         min={min}
         max={max}
         step={step}
-        onChange={onChange}>
+        onChange={onChange}
+      >
         {children}
       </NumberInput>
     );
@@ -133,7 +150,8 @@ export const MechanicInput = ({ name, className, values, attributes, onChange, c
       invalid={error ? true : false}
       error={error}
       disabled={!isEditable}
-      onChange={onChange}>
+      onChange={onChange}
+    >
       {children}
     </TextInput>
   );

--- a/packages/ui-components/src/util/useShiftKey.js
+++ b/packages/ui-components/src/util/useShiftKey.js
@@ -1,0 +1,26 @@
+import { useState, useEffect } from "react";
+
+export const useShiftKey = () => {
+  const [isShiftPressed, setIsShiftPressed] = useState(false);
+
+  useEffect(() => {
+    const handleKeyDown = e => {
+      if (e.key === "Shift") {
+        setIsShiftPressed(true);
+      }
+    };
+    const handleKeyUp = e => {
+      if (e.key === "Shift") {
+        setIsShiftPressed(false);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keyup", handleKeyUp);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keyup", handleKeyUp);
+    };
+  }, []);
+
+  return isShiftPressed;
+};


### PR DESCRIPTION
## What this does

- This addresses #159, holding shift will cause the number input to increment by step * 10 using the arrow keys
- This also addresses the issue observed by Rune that is related to the value being clamped inside the number component
  - you're now allowed to type a value that is out of min/max range
  - the number input component just won't emit this value, so you don't get a re-render
  - the number input component will display an error message

## Pending changes

- I think the min/max validation shouldn't happen inside the number component but rather at the parent level
- However, I believe this is a bigger refactor, as we'd need to refactor the parent, so it stops event emission if there is a validation error somewhere along its children
- The current behavior (with the custom validators a user can provide) is that the function will re-render, even if some input field has a validation error

## Next steps

Before tackling the potential refactor, I'd like @fdoflorenzano take on the potential refactor.

I'd also like @runemadsen to check, if this new number input behavior (allowing out-of-range values but erroring) fixes the issue he mentioned.

Also @bravomartin should check if the 10x step is what he had in mind.
