### PR TITLE
All pretty pretty!

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,17 +1,17 @@
 ---
 name: "\U0001F41B Bug report"
 about: Report an issue with Mechanic.
-title: ''
-labels: 'bug:bug:'
-assignees: ''
-
+title: ""
+labels: "bug:bug:"
+assignees: ""
 ---
 
 **Describe the bug**
-A description of what the bug or issue is. 
+A description of what the bug or issue is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,9 +24,10 @@ A description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here. Feel free to add labels related to the issue. Is it UI related? Core functionality related?

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,7 +4,7 @@
   "tabWidth": 2,
   "useTabs": false,
   "arrowParens": "avoid",
-  "jsxBracketSameLine": true,
+  "bracketSameLine": false,
   "trailingComma": "none",
   "overrides": [
     {

--- a/doc/doc.md
+++ b/doc/doc.md
@@ -49,18 +49,18 @@ For example, the following `inputs` export says the corresponding design functio
 export const inputs = {
   width: {
     type: "number",
-    default: 400,
+    default: 400
   },
   height: {
     type: "number",
     default: 300,
     min: 200,
-    max: 400,
+    max: 400
   },
   name: {
     type: "text",
-    default: "John",
-  },
+    default: "John"
+  }
 };
 ```
 
@@ -76,7 +76,7 @@ For example, the following `settings` export is for an function that generates a
 ```javascript
 export const settings = {
   engine: require("@mechanic-design/engine-p5"),
-  animated: true,
+  animated: true
 };
 ```
 
@@ -118,46 +118,46 @@ export const inputs = {
   width: {
     type: "number",
     default: 400,
-    validation: (v) => (v < 410 || v > 420 ? null : "Out of range"),
+    validation: v => (v < 410 || v > 420 ? null : "Out of range")
   },
   height: {
     type: "number",
-    default: 300,
+    default: 300
   },
   primaryColor: {
     type: "color",
     model: "hex",
-    default: "#FF0000",
+    default: "#FF0000"
   },
   secondaryColor: {
     type: "color",
     options: ["#00FFFF", "#FF00FF", "#FFFF00"],
-    default: "#00FFFF",
+    default: "#00FFFF"
   },
   numberOfRects: {
     type: "number",
     default: 2,
-    options: [2, 3, 4],
-  },
+    options: [2, 3, 4]
+  }
 };
 
 export const presets = {
   medium: {
     width: 800,
-    height: 600,
+    height: 600
   },
   large: {
     width: 1600,
-    height: 1200,
+    height: 1200
   },
   extraLarge: {
     width: 3200,
-    height: 2400,
-  },
+    height: 2400
+  }
 };
 
 export const settings = {
-  engine: require("@mechanic-design/engine-canvas"),
+  engine: require("@mechanic-design/engine-canvas")
 };
 ```
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,4 @@
 {
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "version": "2.0.0-beta.9"
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "bootstrap": "lerna bootstrap --hoist",
     "test": "lerna run test --stream",
     "nuke": "rm -r node_modules; for d in packages/*/node_modules; do echo $d; rm -r $d; done",
+    "prettier": "prettier . --check",
+    "prettier:format": "prettier . --write",
     "publish": "lerna publish",
     "publish:local": "lerna exec -- yalc push",
     "build:dsiLogoMaker": "cd packages/dsi-logo-maker && npm run build"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "bootstrap": "lerna bootstrap --hoist",
     "test": "lerna run test --stream",
     "nuke": "rm -r node_modules; for d in packages/*/node_modules; do echo $d; rm -r $d; done",
-    "prettier": "prettier . --check",
-    "prettier:format": "prettier . --write",
+    "prettier": "prettier --config .prettierrc --check .",
+    "prettier:format": "prettier --config .prettierrc --write . ",
     "publish": "lerna publish",
     "publish:local": "lerna exec -- yalc push",
     "build:dsiLogoMaker": "cd packages/dsi-logo-maker && npm run build"

--- a/packages/cli/commands/build.js
+++ b/packages/cli/commands/build.js
@@ -1,35 +1,35 @@
 const path = require("path");
-module.exports = (getCommandHandler) => ({
+module.exports = getCommandHandler => ({
   command: "build [configPath] [functionsPath] [distDir]",
   aliases: ["b"],
   desc: "Builds local project",
-  builder: (yargs) =>
+  builder: yargs =>
     yargs
       .options({
         configPath: {
           type: "string",
-          description: "Path to mechanic config file",
+          description: "Path to mechanic config file"
         },
         functionsPath: {
           type: "string",
-          description: "Path to directory containing design functions",
+          description: "Path to directory containing design functions"
         },
         inputsPath: {
           type: "string",
-          description: "Path to directory containing custom input components",
+          description: "Path to directory containing custom input components"
         },
         appCompsPath: {
           type: "string",
-          description: "Path to directory containing custom app components",
+          description: "Path to directory containing custom app components"
         },
         staticPath: {
           type: "string",
-          description: "Path to static directory of files to serve",
+          description: "Path to static directory of files to serve"
         },
         distDir: {
           type: "string",
-          description: "Custom build directory",
-        },
+          description: "Custom build directory"
+        }
       })
       .default("configPath", path.normalize("./mechanic.config.js"))
       .default("functionsPath", path.normalize("./functions"))
@@ -37,5 +37,5 @@ module.exports = (getCommandHandler) => ({
       .default("inputsPath", path.normalize("./inputs"))
       .default("appCompsPath", path.normalize("./app"))
       .default("staticPath", path.normalize("./static")),
-  handler: getCommandHandler("build"),
+  handler: getCommandHandler("build")
 });

--- a/packages/cli/commands/dev.js
+++ b/packages/cli/commands/dev.js
@@ -1,34 +1,34 @@
 const path = require("path");
-module.exports = (getCommandHandler) => ({
+module.exports = getCommandHandler => ({
   command: "dev [port] [configPath] [functionsPath]",
   aliases: ["d"],
   desc: "Starts local dev server for mechanic project",
-  builder: (yargs) =>
+  builder: yargs =>
     yargs
       .options({
         port: {
-          description: "Custom port to serve app",
+          description: "Custom port to serve app"
         },
         configPath: {
           type: "string",
-          description: "Path to mechanic config file",
+          description: "Path to mechanic config file"
         },
         functionsPath: {
           type: "string",
-          description: "Path to directory containing design functions",
+          description: "Path to directory containing design functions"
         },
         inputsPath: {
           type: "string",
-          description: "Path to directory containing custom input components",
+          description: "Path to directory containing custom input components"
         },
         appCompsPath: {
           type: "string",
-          description: "Path to directory containing custom app components",
+          description: "Path to directory containing custom app components"
         },
         staticPath: {
           type: "string",
-          description: "Path to static directory of files to serve",
-        },
+          description: "Path to static directory of files to serve"
+        }
       })
       .default("port", 3000)
       .default("configPath", path.normalize("./mechanic.config.js"))
@@ -36,5 +36,5 @@ module.exports = (getCommandHandler) => ({
       .default("inputsPath", path.normalize("./inputs"))
       .default("appCompsPath", path.normalize("./app"))
       .default("staticPath", path.normalize("./static")),
-  handler: getCommandHandler("dev"),
+  handler: getCommandHandler("dev")
 });

--- a/packages/cli/commands/index.js
+++ b/packages/cli/commands/index.js
@@ -2,7 +2,7 @@ const cli = require("yargs");
 const path = require("path");
 const resolveCwd = require("resolve-cwd");
 const {
-  colors: { fail },
+  colors: { fail }
 } = require("@mechanic-design/utils");
 
 const { mechanic, getIsMechanicProject } = require("./utils");
@@ -72,7 +72,7 @@ const buildLocalCommands = (cli, isMechanicProject) => {
   }
 
   const getCommandHandler = (commandName, handler) => {
-    return (argv) => {
+    return argv => {
       const localCmd = resolveLocalCommand(commandName) || (() => {});
       const args = { ...argv, directory };
       return handler ? handler(args, localCmd) : localCmd(args);

--- a/packages/cli/commands/new.js
+++ b/packages/cli/commands/new.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const inquirer = require("inquirer");
 const {
-  spinners: { mechanicSpinner: spinner },
+  spinners: { mechanicSpinner: spinner }
 } = require("@mechanic-design/utils");
 const { create, options, askToInstall } = require("create-mechanic");
 const {
@@ -9,7 +9,7 @@ const {
   directoryExists,
   generateFunctionTemplate,
   getFunctionQuestions,
-  content,
+  content
 } = require("create-mechanic/new-function");
 
 const { getIsMechanicProject } = require("./utils");
@@ -17,10 +17,10 @@ const { getIsMechanicProject } = require("./utils");
 const log = console.log;
 const logSuccess = spinner.succeed;
 const logFail = spinner.fail;
-const sleep = (ms = 1000) => new Promise((resolve) => setTimeout(resolve, ms));
+const sleep = (ms = 1000) => new Promise(resolve => setTimeout(resolve, ms));
 const nullishCoalescingOp = (arg1, arg2) => (arg1 != null ? arg1 : arg2);
 
-const newFunctionCommand = async (argv) => {
+const newFunctionCommand = async argv => {
   const isMechanicProject = getIsMechanicProject();
   if (!isMechanicProject) {
     logFail(content.notMechanicProjectError);
@@ -66,7 +66,7 @@ const newFunctionCommand = async (argv) => {
     {
       functionName,
       usesBase: typeOfBaseUsed,
-      base,
+      base
     },
     { ...config, isFirst: false }
   );
@@ -92,7 +92,7 @@ const newFunctionCommand = async (argv) => {
     {
       typeOfBaseUsed: usesBase,
       base: finalBase,
-      functionName: finalFunctionName,
+      functionName: finalFunctionName
     },
     config
   );
@@ -109,16 +109,16 @@ module.exports = {
   command: "new",
   aliases: ["n"],
   desc: "Creates new mechanic project and design function",
-  builder: (yargs) =>
+  builder: yargs =>
     yargs.options(options).command({
       command: "function",
       aliases: ["f"],
       desc: "Creates new mechanic design function in existing mechanic project",
-      builder: (yargs) => yargs,
-      handler: newFunctionCommand,
+      builder: yargs => yargs,
+      handler: newFunctionCommand
     }),
-  handler: (argv) => {
+  handler: argv => {
     argv._ = argv._.slice(1);
     create(argv);
-  },
+  }
 };

--- a/packages/cli/commands/serve.js
+++ b/packages/cli/commands/serve.js
@@ -1,25 +1,25 @@
 const path = require("path");
-module.exports = (getCommandHandler) => ({
+module.exports = getCommandHandler => ({
   command: "serve [port] [configPath] [distDir]",
   aliases: ["s"],
   desc: "Starts local server for built mechanic project",
-  builder: (yargs) =>
+  builder: yargs =>
     yargs
       .options({
         port: {
-          description: "Custom port to serve app",
+          description: "Custom port to serve app"
         },
         configPath: {
           type: "string",
-          description: "Path to mechanic config file",
+          description: "Path to mechanic config file"
         },
         distDir: {
           type: "string",
-          description: "Custom build directory",
-        },
+          description: "Custom build directory"
+        }
       })
       .default("port", 3000)
       .default("configPath", path.normalize("./mechanic.config.js"))
       .default("distDir", path.normalize("./dist")),
-  handler: getCommandHandler("serve"),
+  handler: getCommandHandler("serve")
 });

--- a/packages/cli/commands/utils.js
+++ b/packages/cli/commands/utils.js
@@ -22,5 +22,5 @@ const getIsMechanicProject = () => {
 
 module.exports = {
   mechanic,
-  getIsMechanicProject,
+  getIsMechanicProject
 };

--- a/packages/core/app/App.js
+++ b/packages/core/app/App.js
@@ -15,10 +15,19 @@ const Layout = ({ funcName, functions, mainRef, iframeRef }) => {
   return (
     <div className={css.root}>
       {!settings.hideFeedback && (
-        <Feedback href="https://forms.gle/uBTn8oVThZHVghV89">Got feedback?</Feedback>
+        <Feedback href="https://forms.gle/uBTn8oVThZHVghV89">
+          Got feedback?
+        </Feedback>
       )}
-      <SideBar name={funcName} exports={functions[funcName]} iframe={iframeRef} mainRef={mainRef}>
-        {!settings.hideNavigation && <Nav name={funcName} functions={functions} />}
+      <SideBar
+        name={funcName}
+        exports={functions[funcName]}
+        iframe={iframeRef}
+        mainRef={mainRef}
+      >
+        {!settings.hideNavigation && (
+          <Nav name={funcName} functions={functions} />
+        )}
       </SideBar>
       <main className={css.main} ref={mainRef}>
         <iframe
@@ -44,7 +53,12 @@ const AppComponent = () => {
             key={`route-${name}`}
             path={[`/${name}`]}
             render={() => (
-              <Layout funcName={name} functions={functions} iframeRef={iframe} mainRef={mainRef} />
+              <Layout
+                funcName={name}
+                functions={functions}
+                iframeRef={iframe}
+                mainRef={mainRef}
+              />
             )}
           />
         ))}

--- a/packages/core/app/components/Feedback.js
+++ b/packages/core/app/components/Feedback.js
@@ -3,7 +3,14 @@ import PropTypes from "prop-types";
 import classnames from "classnames";
 import * as css from "./Feedback.module.css";
 
-export const Feedback = ({ className, href, variant, onClick, children, disabled }) => {
+export const Feedback = ({
+  className,
+  href,
+  variant,
+  onClick,
+  children,
+  disabled
+}) => {
   const classes = classnames(css.root, {
     [className]: className,
     [css[variant]]: css[variant]

--- a/packages/core/app/components/Input.js
+++ b/packages/core/app/components/Input.js
@@ -11,7 +11,8 @@ import {
 } from "@mechanic-design/ui-components";
 import { customComponents } from "../INPUTS";
 
-const uid = (prefix = "comp") => prefix + "-" + Math.random().toString(36).substring(2, 16);
+const uid = (prefix = "comp") =>
+  prefix + "-" + Math.random().toString(36).substring(2, 16);
 
 const baseComponents = {
   text: props => {
@@ -28,7 +29,9 @@ const baseComponents = {
     if (options) {
       return <OptionInput {...props} options={options} />;
     }
-    return <NumberInput min={min} max={max} step={step} slider={slider} {...props} />;
+    return (
+      <NumberInput min={min} max={max} step={step} slider={slider} {...props} />
+    );
   },
   boolean: props => <BooleanInput {...props} />,
   color: props => {
@@ -46,7 +49,14 @@ const baseComponents = {
   }
 };
 
-export const Input = ({ name, className, values, inputDef, onChange, children }) => {
+export const Input = ({
+  name,
+  className,
+  values,
+  inputDef,
+  onChange,
+  children
+}) => {
   const id = useRef(uid("mechanic-input"));
   const { type } = inputDef;
   if (type in customComponents) {
@@ -71,7 +81,11 @@ export const Input = ({ name, className, values, inputDef, onChange, children })
 
   const value = values[name];
   const isEditable =
-    editable === undefined ? true : typeof editable === "function" ? !!editable(values) : editable;
+    editable === undefined
+      ? true
+      : typeof editable === "function"
+      ? !!editable(values)
+      : editable;
   const actualValue = value === undefined ? _default : value;
   const error = validation ? validation(values) : null;
 
@@ -89,7 +103,8 @@ export const Input = ({ name, className, values, inputDef, onChange, children })
       error={error}
       disabled={!isEditable}
       onChange={onChange}
-      inputDef={inputDef}>
+      inputDef={inputDef}
+    >
       {children}
     </Component>
   );

--- a/packages/core/app/components/Nav.js
+++ b/packages/core/app/components/Nav.js
@@ -25,7 +25,8 @@ export const Nav = ({ name, functions }) => {
             className={css.navigationSelect}
             onChange={({ target }) => history.push(`/${target.value}`)}
             name={name}
-            value={name}>
+            value={name}
+          >
             <option key="disabled" disabled>
               Select...
             </option>

--- a/packages/core/app/components/SideBar.module.css
+++ b/packages/core/app/components/SideBar.module.css
@@ -60,12 +60,14 @@
 .undo {
   left: 0;
 
-  border-radius: var(--mechanic-input-height-half) 0 0 var(--mechanic-input-height-half);
+  border-radius: var(--mechanic-input-height-half) 0 0
+    var(--mechanic-input-height-half);
 }
 
 .redo {
   right: 0;
-  border-radius: 0 var(--mechanic-input-height-half) var(--mechanic-input-height-half) 0;
+  border-radius: 0 var(--mechanic-input-height-half)
+    var(--mechanic-input-height-half) 0;
 }
 
 .grow {

--- a/packages/core/app/components/utils/presets.js
+++ b/packages/core/app/components/utils/presets.js
@@ -4,7 +4,13 @@ const DEFAULT_PRESET_VALUE = "Default values";
 const getPossiblePresets = presets =>
   [NO_PRESET_VALUE].concat(Object.keys(presets)).concat([DEFAULT_PRESET_VALUE]);
 
-const addPresetsAsSources = (inputValue, inputName, presets, inputs, values) => {
+const addPresetsAsSources = (
+  inputValue,
+  inputName,
+  presets,
+  inputs,
+  values
+) => {
   const sources = [{ [inputName]: inputValue }];
   if (inputName === "preset") {
     if (inputValue === DEFAULT_PRESET_VALUE) {
@@ -20,7 +26,8 @@ const addPresetsAsSources = (inputValue, inputName, presets, inputs, values) => 
   } else if (
     values.hasOwnProperty("preset") &&
     values.preset !== NO_PRESET_VALUE &&
-    (values.preset === DEFAULT_PRESET_VALUE || presets[values.preset].hasOwnProperty(inputName))
+    (values.preset === DEFAULT_PRESET_VALUE ||
+      presets[values.preset].hasOwnProperty(inputName))
   ) {
     sources.push({ preset: NO_PRESET_VALUE });
   }

--- a/packages/core/app/components/utils/useInteractiveInputs.js
+++ b/packages/core/app/components/utils/useInteractiveInputs.js
@@ -32,7 +32,8 @@ const useInteractiveInputs = (inputs, iframe, onChange) => {
 
   useEffect(() => {
     const onLoad = () => {
-      iframeRoot.current = iframe.current.contentDocument.getElementById("root");
+      iframeRoot.current =
+        iframe.current.contentDocument.getElementById("root");
       for (const [eventType, handler] of handlers) {
         iframeRoot.current.addEventListener(eventType, handler);
       }

--- a/packages/core/app/components/utils/useSeedHistory.js
+++ b/packages/core/app/components/utils/useSeedHistory.js
@@ -93,7 +93,8 @@ function undoReducer(state, action) {
   }
 }
 
-const getNewSeed = () => seedrandom(null, { pass: (_, seed) => ({ seed }) }).seed;
+const getNewSeed = () =>
+  seedrandom(null, { pass: (_, seed) => ({ seed }) }).seed;
 
 export function useSeedHistory(functionName) {
   const key = `--${functionName}-seed`;

--- a/packages/core/app/components/utils/useValues.js
+++ b/packages/core/app/components/utils/useValues.js
@@ -5,9 +5,12 @@ import { NO_PRESET_VALUE, addPresetsAsSources } from "./presets.js";
 import { resetOtherInteractive } from "./useInteractiveInputs.js";
 
 const isEmptyObject = obj =>
-  obj && Object.keys(obj).length === 0 && Object.getPrototypeOf(obj) === Object.prototype;
+  obj &&
+  Object.keys(obj).length === 0 &&
+  Object.getPrototypeOf(obj) === Object.prototype;
 
-const isSerializable = obj => isEmptyObject(obj) || !(JSON.stringify(obj) === "{}");
+const isSerializable = obj =>
+  isEmptyObject(obj) || !(JSON.stringify(obj) === "{}");
 
 const copySerializable = obj => {
   if (typeof obj !== "object") {
@@ -19,7 +22,10 @@ const copySerializable = obj => {
     for (const o of obj) {
       if (isSerializable(o)) {
         copy.push(copySerializable(o));
-      } else console.warn("Unserializable object ignored for local storage persistance.");
+      } else
+        console.warn(
+          "Unserializable object ignored for local storage persistance."
+        );
     }
   } else {
     copy = {};
@@ -28,7 +34,10 @@ const copySerializable = obj => {
     for (const key of keys) {
       if (isSerializable(obj[key])) {
         copy[key] = copySerializable(obj[key]);
-      } else console.warn("Unserializable object ignored for local storage persistance.");
+      } else
+        console.warn(
+          "Unserializable object ignored for local storage persistance."
+        );
     }
   }
   return copy;
@@ -83,7 +92,9 @@ function initialize(key, initialState) {
  * @param {any} initialState - Default initial value
  */
 function useLocalStorageState(key, initialState, clean) {
-  const [value, __setValue] = useImmer(() => clean(initialize(key, initialState)));
+  const [value, __setValue] = useImmer(() =>
+    clean(initialize(key, initialState))
+  );
   const isUpdateFromListener = useRef(false);
 
   useEffect(() => {
@@ -166,7 +177,10 @@ const generateHashFromInputsObject = inputs => {
 };
 
 const useValues = (functionName, functionInputs, presets) => {
-  const clean = useCallback(object => cleanValues(object, functionInputs), [functionInputs]);
+  const clean = useCallback(
+    object => cleanValues(object, functionInputs),
+    [functionInputs]
+  );
   const initialValue = useMemo(() => {
     return Object.fromEntries([
       ["preset", NO_PRESET_VALUE],
@@ -179,12 +193,26 @@ const useValues = (functionName, functionInputs, presets) => {
   const inputsHash = generateHashFromInputsObject(functionInputs);
   const storageKey = `mechanic_df_${functionName}_${inputsHash}`;
 
-  const [values, __setValues] = useLocalStorageState(storageKey, initialValue, clean);
+  const [values, __setValues] = useLocalStorageState(
+    storageKey,
+    initialValue,
+    clean
+  );
 
   const setValues = (name, value) => {
     __setValues(draft => {
-      const sources = addPresetsAsSources(value, name, presets, functionInputs, draft);
-      const sourcesAndInteractive = resetOtherInteractive(sources, functionInputs, name);
+      const sources = addPresetsAsSources(
+        value,
+        name,
+        presets,
+        functionInputs,
+        draft
+      );
+      const sourcesAndInteractive = resetOtherInteractive(
+        sources,
+        functionInputs,
+        name
+      );
       for (let source of sourcesAndInteractive) {
         for (let prop in source) {
           draft[prop] = source[prop];

--- a/packages/core/app/webpackConfigGenerator.cjs
+++ b/packages/core/app/webpackConfigGenerator.cjs
@@ -59,7 +59,10 @@ module.exports = function (
             }
           ]
         ],
-        plugins: [resolve("react-hot-loader/babel"), resolve("@babel/plugin-transform-runtime")],
+        plugins: [
+          resolve("react-hot-loader/babel"),
+          resolve("@babel/plugin-transform-runtime")
+        ],
         env: {
           test: {
             presets: [resolve("@babel/preset-env")]
@@ -72,28 +75,39 @@ module.exports = function (
   const functions = {
     test: /FUNCTIONS/,
     use: [
-      { loader: path.resolve(__dirname, "./function-loader.cjs"), options: { designFunctions } }
+      {
+        loader: path.resolve(__dirname, "./function-loader.cjs"),
+        options: { designFunctions }
+      }
     ]
   };
 
   const inputs = {
     test: /INPUTS/,
     use: [
-      { loader: path.resolve(__dirname, "./input-loader.cjs"), options: { inputs: inputsData } }
+      {
+        loader: path.resolve(__dirname, "./input-loader.cjs"),
+        options: { inputs: inputsData }
+      }
     ]
   };
 
   const appComponents = {
     test: /APP/,
     use: [
-      { loader: path.resolve(__dirname, "./app-components-loader.cjs"), options: { appCompsPath } }
+      {
+        loader: path.resolve(__dirname, "./app-components-loader.cjs"),
+        options: { appCompsPath }
+      }
     ]
   };
 
   const mechanicCss = {
     test: /\.(css)$/,
     issuer: isMechanicCondition,
-    use: [isProduction ? MiniCssExtractPlugin.loader : resolve("style-loader")].concat([
+    use: [
+      isProduction ? MiniCssExtractPlugin.loader : resolve("style-loader")
+    ].concat([
       {
         loader: resolve("css-loader"),
         options: {
@@ -194,7 +208,10 @@ module.exports = function (
     {
       app: isProduction
         ? path.resolve(__dirname, "./index.js")
-        : [resolve("webpack-hot-middleware/client"), path.resolve(__dirname, "./index.js")]
+        : [
+            resolve("webpack-hot-middleware/client"),
+            path.resolve(__dirname, "./index.js")
+          ]
     }
   );
 

--- a/packages/core/src/base-inputs/boolean.js
+++ b/packages/core/src/base-inputs/boolean.js
@@ -1,4 +1,8 @@
-import { getTypeValidationProperty, validationProperty, editableProperty } from "./utils.js";
+import {
+  getTypeValidationProperty,
+  validationProperty,
+  editableProperty
+} from "./utils.js";
 
 export default {
   typeName: "boolean",

--- a/packages/core/src/base-inputs/image.js
+++ b/packages/core/src/base-inputs/image.js
@@ -1,4 +1,8 @@
-import { getTypeValidationProperty, validationProperty, editableProperty } from "./utils.js";
+import {
+  getTypeValidationProperty,
+  validationProperty,
+  editableProperty
+} from "./utils.js";
 
 export default {
   typeName: "image",

--- a/packages/core/src/base-inputs/number.js
+++ b/packages/core/src/base-inputs/number.js
@@ -23,10 +23,14 @@ export default {
   validation: (inputValue, input) => {
     if (typeof inputValue !== "number" && typeof inputValue !== "string") {
       return `Supplied input value ${inputValue} is expected to be of type "number", not ${typeof inputValue}.`;
-    } else if (typeof inputValue === "string" && Number.isNaN(parseFloat(inputValue))) {
+    } else if (
+      typeof inputValue === "string" &&
+      Number.isNaN(parseFloat(inputValue))
+    ) {
       return `Supplied input value ${inputValue} is unparsable string.`;
     }
-    const value = typeof inputValue === "string" ? parseFloat(inputValue) : inputValue;
+    const value =
+      typeof inputValue === "string" ? parseFloat(inputValue) : inputValue;
     if (hasKey(input, "options")) {
       const { options } = input;
       if (Array.isArray(options) && !options.includes(value)) {

--- a/packages/core/src/base-inputs/utils.js
+++ b/packages/core/src/base-inputs/utils.js
@@ -31,9 +31,9 @@ export const getOptionsProperty = type => ({
     else if (!Array.isArray(value)) {
       // It should be consistent with 'default' property
       if (!Object.keys(value).includes(input.default)) {
-        return `Default value ${input.default} is not present in given options: ${Object.keys(
-          value
-        )}. `;
+        return `Default value ${
+          input.default
+        } is not present in given options: ${Object.keys(value)}. `;
       }
       // All values should be consistent with the input type
       for (let option in value) {

--- a/packages/core/src/commands/build.cjs
+++ b/packages/core/src/commands/build.cjs
@@ -32,7 +32,9 @@ const command = async argv => {
     spinner.fail(`Mechanic config file (${configPath}) not found`);
     return;
   } else {
-    spinner.succeed(`Mechanic config file loaded: ${success(path.relative(".", configPath))}`);
+    spinner.succeed(
+      `Mechanic config file loaded: ${success(path.relative(".", configPath))}`
+    );
   }
 
   // Seek functions path
@@ -43,7 +45,9 @@ const command = async argv => {
     return;
   } else {
     spinner.succeed(
-      `Design functions directory found: ${success(path.relative(".", functionsPath))}`
+      `Design functions directory found: ${success(
+        path.relative(".", functionsPath)
+      )}`
     );
   }
 
@@ -53,16 +57,24 @@ const command = async argv => {
   if (!staticPath) {
     spinner.succeed(`Static directory file not found.`);
   } else {
-    spinner.succeed(`Static directory found: ${success(path.relative(".", staticPath))}`);
+    spinner.succeed(
+      `Static directory found: ${success(path.relative(".", staticPath))}`
+    );
   }
 
   // Seek custom inputs path
   spinner.start("Seeking custom inputs directory...");
   const inputsPath = await getInputsPath(argv.inputsPath, config);
   if (inputsPath) {
-    spinner.succeed(`Custom inputs directory found: ${success(path.relative(".", inputsPath))}`);
+    spinner.succeed(
+      `Custom inputs directory found: ${success(
+        path.relative(".", inputsPath)
+      )}`
+    );
   } else {
-    spinner.succeed(`Custom inputs directory not found. No custom inputs being used!`);
+    spinner.succeed(
+      `Custom inputs directory not found. No custom inputs being used!`
+    );
   }
 
   // Seek custom app components path
@@ -70,7 +82,9 @@ const command = async argv => {
   const appCompsPath = await getAppCompsPath(argv.appCompsPath, config);
   if (appCompsPath) {
     spinner.succeed(
-      `Custom app components directory found: ${success(path.relative(".", appCompsPath))}`
+      `Custom app components directory found: ${success(
+        path.relative(".", appCompsPath)
+      )}`
     );
   } else {
     spinner.succeed(
@@ -85,7 +99,11 @@ const command = async argv => {
   spinner.succeed("Temp files created!");
 
   const distDir = path.normalize(
-    config.distDir != null ? config.distDir : argv.distDir != null ? argv.distDir : "./dist"
+    config.distDir != null
+      ? config.distDir
+      : argv.distDir != null
+      ? argv.distDir
+      : "./dist"
   );
   const publicPath = config.publicPath ?? "/";
 
@@ -111,7 +129,9 @@ const command = async argv => {
           })
         );
     } else {
-      spinner.succeed(success(`Mechanic app built at directory ${distDir}/!\n`));
+      spinner.succeed(
+        success(`Mechanic app built at directory ${distDir}/!\n`)
+      );
       console.log(
         "You can serve locally and use the builded app using the `npm run serve` command!"
       );

--- a/packages/core/src/commands/dev.cjs
+++ b/packages/core/src/commands/dev.cjs
@@ -38,7 +38,9 @@ const command = async argv => {
     spinner.fail(`Mechanic config file (${configPath}) not found`);
     return;
   } else {
-    spinner.succeed(`Mechanic config file loaded: ${success(path.relative(".", configPath))}`);
+    spinner.succeed(
+      `Mechanic config file loaded: ${success(path.relative(".", configPath))}`
+    );
   }
 
   // Seek functions path
@@ -49,7 +51,9 @@ const command = async argv => {
     return;
   } else {
     spinner.succeed(
-      `Design functions directory found: ${success(path.relative(".", functionsPath))}`
+      `Design functions directory found: ${success(
+        path.relative(".", functionsPath)
+      )}`
     );
   }
 
@@ -59,16 +63,24 @@ const command = async argv => {
   if (!staticPath) {
     spinner.succeed(`Static directory file not found.`);
   } else {
-    spinner.succeed(`Static directory found: ${success(path.relative(".", staticPath))}`);
+    spinner.succeed(
+      `Static directory found: ${success(path.relative(".", staticPath))}`
+    );
   }
 
   // Seek custom inputs path
   spinner.start("Seeking custom inputs directory...");
   const inputsPath = await getInputsPath(argv.inputsPath, config);
   if (inputsPath) {
-    spinner.succeed(`Custom inputs directory found: ${success(path.relative(".", inputsPath))}`);
+    spinner.succeed(
+      `Custom inputs directory found: ${success(
+        path.relative(".", inputsPath)
+      )}`
+    );
   } else {
-    spinner.succeed(`Custom inputs directory not found. No custom inputs being used!`);
+    spinner.succeed(
+      `Custom inputs directory not found. No custom inputs being used!`
+    );
   }
 
   // Seek custom app components path
@@ -76,7 +88,9 @@ const command = async argv => {
   const appCompsPath = await getAppCompsPath(argv.appCompsPath, config);
   if (appCompsPath) {
     spinner.succeed(
-      `Custom app components directory found: ${success(path.relative(".", appCompsPath))}`
+      `Custom app components directory found: ${success(
+        path.relative(".", appCompsPath)
+      )}`
     );
   } else {
     spinner.succeed(
@@ -99,14 +113,19 @@ const command = async argv => {
         res.format({
           "font/otf": () =>
             res.sendFile(
-              require.resolve("@mechanic-design/fonts/PP-Object-Sans/PPObjectSans-Regular.otf")
+              require.resolve(
+                "@mechanic-design/fonts/PP-Object-Sans/PPObjectSans-Regular.otf"
+              )
             )
         });
       else
         res.format({
-          default: () => res.sendFile(path.resolve(__dirname, "./html/loading.html")),
-          "image/svg+xml": () => res.sendFile(path.resolve(__dirname, "../../app/favicon.svg")),
-          "text/html": () => res.sendFile(path.resolve(__dirname, "./html/loading.html")),
+          default: () =>
+            res.sendFile(path.resolve(__dirname, "./html/loading.html")),
+          "image/svg+xml": () =>
+            res.sendFile(path.resolve(__dirname, "../../app/favicon.svg")),
+          "text/html": () =>
+            res.sendFile(path.resolve(__dirname, "./html/loading.html")),
           "application/json": () => res.json({ loading: true, status })
         });
     }
@@ -125,7 +144,8 @@ const command = async argv => {
   spinner.start("Generating temp files to serve...");
   const [customInputs, inputScriptContent] = generateInputScript(inputsPath);
   const inputsData = { inputsPath, inputScriptContent, customInputs };
-  const [designFunctions, funcsTempDirObj] = generateFuncTempScripts(functionsPath);
+  const [designFunctions, funcsTempDirObj] =
+    generateFuncTempScripts(functionsPath);
   spinner.succeed("Temp files created!");
   spinner.start("Loading webpack compilation...");
 

--- a/packages/core/src/commands/html/loading.html
+++ b/packages/core/src/commands/html/loading.html
@@ -76,7 +76,9 @@
         </path>
       </svg>
 
-      <p>This page will reload when <strong>Mechanic</strong> project is ready!</p>
+      <p>
+        This page will reload when <strong>Mechanic</strong> project is ready!
+      </p>
     </div>
     <script>
       let ready = false;

--- a/packages/core/src/commands/serve.cjs
+++ b/packages/core/src/commands/serve.cjs
@@ -2,7 +2,12 @@ const path = require("path");
 const express = require("express");
 const portfinder = require("portfinder");
 const history = require("connect-history-api-fallback");
-const { getConfig, setCustomInterrupt, greet, goodbye } = require("./utils.cjs");
+const {
+  getConfig,
+  setCustomInterrupt,
+  greet,
+  goodbye
+} = require("./utils.cjs");
 
 const {
   spinners: { mechanicSpinner: spinner },
@@ -23,7 +28,9 @@ const command = async argv => {
     spinner.fail(`Mechanic config file (${configPath}) not found`);
     return;
   } else {
-    spinner.succeed(`Mechanic config file loaded: ${success(path.relative(".", configPath))}`);
+    spinner.succeed(
+      `Mechanic config file loaded: ${success(path.relative(".", configPath))}`
+    );
   }
   const distDir = path.normalize(
     argv.distDir !== "./dist" ? argv.distDir : config.distDir || "./dist"
@@ -41,8 +48,10 @@ const command = async argv => {
       next();
     } else {
       res.format({
-        default: () => res.sendFile(path.resolve(__dirname, "./html/loading.html")),
-        "text/html": () => res.sendFile(path.resolve(__dirname, "./html/loading.html")),
+        default: () =>
+          res.sendFile(path.resolve(__dirname, "./html/loading.html")),
+        "text/html": () =>
+          res.sendFile(path.resolve(__dirname, "./html/loading.html")),
         "application/json": () => res.json({ loading: true, status })
       });
     }

--- a/packages/core/src/commands/utils.cjs
+++ b/packages/core/src/commands/utils.cjs
@@ -33,7 +33,9 @@ const getInputsPath = async (inputsPath, config) => {
 const getAppCompsPath = async (appCompsPath, config) => {
   const relativePath = appCompsPath || config.appCompsPath || "./app";
   const fullPath = await checkFullPath(relativePath);
-  const indexPath = fullPath ? await checkFullPath(`${relativePath}/index.js`) : null;
+  const indexPath = fullPath
+    ? await checkFullPath(`${relativePath}/index.js`)
+    : null;
   return indexPath ? fullPath : null;
 };
 
@@ -55,11 +57,17 @@ const searchExports = (dir, callback, depth = 0) => {
   });
 };
 
-const setUpFunctionPath = path.resolve(path.join(__dirname, "..", "function-set-up.js"));
-const inputsPath = path.resolve(path.join(__dirname, "..", "..", "app", "INPUTS"));
+const setUpFunctionPath = path.resolve(
+  path.join(__dirname, "..", "function-set-up.js")
+);
+const inputsPath = path.resolve(
+  path.join(__dirname, "..", "..", "app", "INPUTS")
+);
 const getFuncScriptContent = designFunctionPath => `
 import { inputsDefs, inputErrors } from "${inputsPath}";
-import * as designFunction from "${designFunctionPath.split(path.sep).join("/")}";
+import * as designFunction from "${designFunctionPath
+  .split(path.sep)
+  .join("/")}";
 import { setUp } from "${setUpFunctionPath.split(path.sep).join("/")}";
 setUp(inputsDefs, designFunction, inputErrors)
 if (module.hot) {
@@ -82,13 +90,18 @@ const generateFuncTempScripts = functionsPath => {
   });
   Object.entries(designFunctions).map(([name, designFuncObj]) => {
     const tempScriptName = path.join(tempDirObj.name, `${name}.js`);
-    fs.writeFileSync(tempScriptName, getFuncScriptContent(designFuncObj.original));
+    fs.writeFileSync(
+      tempScriptName,
+      getFuncScriptContent(designFuncObj.original)
+    );
     designFunctions[name]["temp"] = tempScriptName;
   });
   return [designFunctions, tempDirObj];
 };
 
-const setUpInputsPath = path.resolve(path.join(__dirname, "..", "input-set-up.js"));
+const setUpInputsPath = path.resolve(
+  path.join(__dirname, "..", "input-set-up.js")
+);
 const inputScriptContent = `
 import { setUp } from "${setUpInputsPath.split(path.sep).join("/")}";
 const [inputsDefs, customComponents, interactiveInputs, inputErrors] = setUp(customInputs);
@@ -121,7 +134,8 @@ const generateInputScript = inputsPath => {
 
 const setCustomInterrupt = (callback, tempDirObjs = []) => {
   process.on("SIGINT", function () {
-    if (tempDirObjs.length > 0) tempDirObjs.forEach(obj => obj.removeCallback());
+    if (tempDirObjs.length > 0)
+      tempDirObjs.forEach(obj => obj.removeCallback());
     callback();
     process.exit();
   });

--- a/packages/core/src/download.js
+++ b/packages/core/src/download.js
@@ -59,7 +59,10 @@ export const download = (data, strFileName, strMimeType) => {
     }
   } //end if dataURL passed?
 
-  blob = payload instanceof myBlob ? payload : new myBlob([payload], { type: mimeType });
+  blob =
+    payload instanceof myBlob
+      ? payload
+      : new myBlob([payload], { type: mimeType });
 
   function dataUrlToBlob(strUrl) {
     var parts = strUrl.split(/[:;,]/),
@@ -97,7 +100,9 @@ export const download = (data, strFileName, strMimeType) => {
     }
 
     // handle non-a[download] safari as best we can:
-    if (/(Version)\/(\d+)\.(\d+)(?:\.(\d+))?.*Safari\//.test(navigator.userAgent)) {
+    if (
+      /(Version)\/(\d+)\.(\d+)(?:\.(\d+))?.*Safari\//.test(navigator.userAgent)
+    ) {
       url = url.replace(/^data:([\w\/\-\+]+)/, defaultMime);
       if (!window.open(url)) {
         // popup blocked, offer direct download:

--- a/packages/core/src/function-set-up.js
+++ b/packages/core/src/function-set-up.js
@@ -29,11 +29,14 @@ const showError = (mainMessage, error) => {
   code.style = "font-size: 15px; color: red;";
   code.appendChild(document.createTextNode(error));
   p.appendChild(code);
-  p.appendChild(document.createTextNode(" - You may find more context in console."));
+  p.appendChild(
+    document.createTextNode(" - You may find more context in console.")
+  );
   div.appendChild(p);
 
   const stackDiv = document.createElement("div");
-  stackDiv.style = "color: white; background: black; border-radius: 10px;padding: 10px;";
+  stackDiv.style =
+    "color: white; background: black; border-radius: 10px;padding: 10px;";
 
   for (let m of [...error.stack.split("\n")]) {
     const p = document.createElement("p");
@@ -73,10 +76,18 @@ const setUp = (inputsDefs, designFunction, inputErrors) => {
         validator.validateValues(values);
         const preparedValues = validator.prepareValues(values);
         const engine = designFunction.settings.engine.run;
-        const mechanic = engine(functionName, designFunction, preparedValues, config);
+        const mechanic = engine(
+          functionName,
+          designFunction,
+          preparedValues,
+          config
+        );
         return mechanic ? mechanic : null;
       } catch (error) {
-        showError(`There was an error running ${functionName} function and/or engine.`, error);
+        showError(
+          `There was an error running ${functionName} function and/or engine.`,
+          error
+        );
         setTimeout(() => {
           throw error;
         }, 0);
@@ -88,7 +99,11 @@ const setUp = (inputsDefs, designFunction, inputErrors) => {
     window.run = functionName => {
       if (error instanceof MechanicInputError) {
         showError(`There was an error loading custom inputs.`, error);
-      } else showError(`There was an error loading ${functionName} function and/or engine.`, error);
+      } else
+        showError(
+          `There was an error loading ${functionName} function and/or engine.`,
+          error
+        );
       return null;
     };
     throw error;

--- a/packages/core/src/input-set-up.js
+++ b/packages/core/src/input-set-up.js
@@ -136,9 +136,16 @@ const setUp = customInputs => {
     Object.entries(customInputs).map(([fileName, fileExport]) => {
       const input = inputProperties.reduce((acc, prop) => {
         const exp = fileExport[prop];
-        const error = exp === undefined ? undefined : validateExportProperty(fileName, prop, exp);
+        const error =
+          exp === undefined
+            ? undefined
+            : validateExportProperty(fileName, prop, exp);
         if (error) errors.push(error);
-        return { ...acc, [prop]: error || exp === undefined ? exportDefault(fileName, prop) : exp };
+        return {
+          ...acc,
+          [prop]:
+            error || exp === undefined ? exportDefault(fileName, prop) : exp
+        };
       }, {});
       return [input.typeName, input];
     })
@@ -155,7 +162,10 @@ const setUp = customInputs => {
   const interactiveInputs = Object.fromEntries(
     Object.entries(inputs)
       .map(([name, properties]) => [name, properties.eventHandlers])
-      .filter(([_, eventObject]) => !!eventObject && Object.keys(eventObject).length > 0)
+      .filter(
+        ([_, eventObject]) =>
+          !!eventObject && Object.keys(eventObject).length > 0
+      )
   );
   return [inputs, customComponents, interactiveInputs, errors];
 };

--- a/packages/core/src/mechanic-utils.js
+++ b/packages/core/src/mechanic-utils.js
@@ -71,7 +71,10 @@ const svgPrepare = (el, serializer) => {
   }
 
   if (!str.match(/^<svg[^>]+"http\:\/\/www\.w3\.org\/1999\/xlink"/)) {
-    str = str.replace(/^<svg/, '<svg xmlns:xlink="http://www.w3.org/1999/xlink"');
+    str = str.replace(
+      /^<svg/,
+      '<svg xmlns:xlink="http://www.w3.org/1999/xlink"'
+    );
   }
   str = '<?xml version="1.0" standalone="no"?>\r\n' + str;
   return str;

--- a/packages/core/src/validation.js
+++ b/packages/core/src/validation.js
@@ -20,7 +20,9 @@ export class MechanicValidator {
     const expectedProperties = ["handler", "inputs", "settings"];
     for (const property of expectedProperties) {
       if (!(property in this.designFunction)) {
-        throw new MechanicError(`Missing export definition "${property}" in design function`);
+        throw new MechanicError(
+          `Missing export definition "${property}" in design function`
+        );
       }
     }
   }
@@ -28,7 +30,9 @@ export class MechanicValidator {
   validateSettings() {
     const engine = this.designFunction.settings?.engine?.run;
     if (engine === undefined) {
-      throw new MechanicError(`Proper engine not found in design function's setting`);
+      throw new MechanicError(
+        `Proper engine not found in design function's setting`
+      );
     }
   }
 
@@ -96,8 +100,13 @@ export class MechanicValidator {
 
     // Check that there are not other values besides inputs and default inputs
     for (let inputName in values) {
-      if (!hasKey(this.designFunction.inputs, inputName) && !hasKey(otherInputs, inputName)) {
-        throw new MechanicError(`Unexpected ${inputName} value received not defined on template.`);
+      if (
+        !hasKey(this.designFunction.inputs, inputName) &&
+        !hasKey(otherInputs, inputName)
+      ) {
+        throw new MechanicError(
+          `Unexpected ${inputName} value received not defined on template.`
+        );
       }
     }
   }

--- a/packages/core/src/webm-writer.js
+++ b/packages/core/src/webm-writer.js
@@ -31,7 +31,8 @@ ArrayBufferDataStream.prototype.writeByte = function (b) {
 };
 
 //Synonym:
-ArrayBufferDataStream.prototype.writeU8 = ArrayBufferDataStream.prototype.writeByte;
+ArrayBufferDataStream.prototype.writeU8 =
+  ArrayBufferDataStream.prototype.writeByte;
 
 ArrayBufferDataStream.prototype.writeU16BE = function (u) {
   this.data[this.pos++] = u >> 8;
@@ -338,7 +339,14 @@ const BlobBufferClass = function (fs) {
                   }
                 };
 
-              fs.write(fd, buffer, 0, buffer.length, newEntry.offset, handleWriteComplete);
+              fs.write(
+                fd,
+                buffer,
+                0,
+                buffer.length,
+                newEntry.offset,
+                handleWriteComplete
+              );
             });
           });
         } else if (fileWriter) {
@@ -369,7 +377,10 @@ const BlobBufferClass = function (fs) {
                 throw new Error("Overwrite crosses blob boundaries");
               }
 
-              if (newEntry.offset == entry.offset && newEntry.length == entry.length) {
+              if (
+                newEntry.offset == entry.offset &&
+                newEntry.length == entry.length
+              ) {
                 // We overwrote the entire block
                 entry.data = newEntry.data;
 
@@ -385,7 +396,10 @@ const BlobBufferClass = function (fs) {
                   .then(function (newEntryArray) {
                     newEntry.data = newEntryArray;
 
-                    entry.data.set(newEntry.data, newEntry.offset - entry.offset);
+                    entry.data.set(
+                      newEntry.data,
+                      newEntry.offset - entry.offset
+                    );
                   });
               }
             }
@@ -765,11 +779,19 @@ const WebMWriterClass = function (ArrayBufferDataStream, BlobBuffer) {
         alphaBuffer.height = source.height;
 
         alphaBufferContext = alphaBuffer.getContext("2d");
-        alphaBufferData = alphaBufferContext.createImageData(alphaBuffer.width, alphaBuffer.height);
+        alphaBufferData = alphaBufferContext.createImageData(
+          alphaBuffer.width,
+          alphaBuffer.height
+        );
       }
 
       let sourceContext = source.getContext("2d"),
-        sourceData = sourceContext.getImageData(0, 0, source.width, source.height).data,
+        sourceData = sourceContext.getImageData(
+          0,
+          0,
+          source.width,
+          source.height
+        ).data,
         destData = alphaBufferData.data,
         dstCursor = 0,
         srcEnd = source.width * source.height * 4;
@@ -960,8 +982,12 @@ const WebMWriterClass = function (ArrayBufferDataStream, BlobBuffer) {
       blobBuffer.write(bufferStream.getAsDataArray());
 
       // Now we know where these top-level elements lie in the file:
-      seekPoints.SegmentInfo.positionEBML.data = fileOffsetToSegmentRelative(segmentInfo.offset);
-      seekPoints.Tracks.positionEBML.data = fileOffsetToSegmentRelative(tracks.offset);
+      seekPoints.SegmentInfo.positionEBML.data = fileOffsetToSegmentRelative(
+        segmentInfo.offset
+      );
+      seekPoints.Tracks.positionEBML.data = fileOffsetToSegmentRelative(
+        tracks.offset
+      );
 
       writtenHeader = true;
     }
@@ -1118,7 +1144,9 @@ const WebMWriterClass = function (ArrayBufferDataStream, BlobBuffer) {
       blobBuffer.write(cuesBuffer.getAsDataArray());
 
       // Now we know where the Cues element has ended up, we can update the SeekHead
-      seekPoints.Cues.positionEBML.data = fileOffsetToSegmentRelative(ebml.offset);
+      seekPoints.Cues.positionEBML.data = fileOffsetToSegmentRelative(
+        ebml.offset
+      );
     }
 
     /**
@@ -1135,10 +1163,14 @@ const WebMWriterClass = function (ArrayBufferDataStream, BlobBuffer) {
       for (let i = 0; i < clusterFrameBuffer.length; i++) {
         rawImageSize +=
           clusterFrameBuffer[i].frame.length +
-          (clusterFrameBuffer[i].alpha ? clusterFrameBuffer[i].alpha.length : 0);
+          (clusterFrameBuffer[i].alpha
+            ? clusterFrameBuffer[i].alpha.length
+            : 0);
       }
 
-      let buffer = new ArrayBufferDataStream(rawImageSize + clusterFrameBuffer.length * 64), // Estimate 64 bytes per block header
+      let buffer = new ArrayBufferDataStream(
+          rawImageSize + clusterFrameBuffer.length * 64
+        ), // Estimate 64 bytes per block header
         cluster = createCluster({
           timecode: Math.round(clusterStartTime)
         });
@@ -1150,7 +1182,11 @@ const WebMWriterClass = function (ArrayBufferDataStream, BlobBuffer) {
       writeEBML(buffer, blobBuffer.pos, cluster);
       blobBuffer.write(buffer.getAsDataArray());
 
-      addCuePoint(DEFAULT_TRACK_NUMBER, Math.round(clusterStartTime), cluster.offset);
+      addCuePoint(
+        DEFAULT_TRACK_NUMBER,
+        Math.round(clusterStartTime),
+        cluster.offset
+      );
 
       clusterFrameBuffer = [];
       clusterStartTime += clusterDuration;
@@ -1163,7 +1199,9 @@ const WebMWriterClass = function (ArrayBufferDataStream, BlobBuffer) {
         if (options.frameRate) {
           options.frameDuration = 1000 / options.frameRate;
         } else {
-          throw new Error("Missing required frameDuration or frameRate setting");
+          throw new Error(
+            "Missing required frameDuration or frameRate setting"
+          );
         }
       }
 
@@ -1173,7 +1211,10 @@ const WebMWriterClass = function (ArrayBufferDataStream, BlobBuffer) {
       if (options.alphaQuality === undefined) {
         options.alphaQuality = options.quality;
       } else {
-        options.alphaQuality = Math.max(Math.min(options.alphaQuality, 0.99999), 0);
+        options.alphaQuality = Math.max(
+          Math.min(options.alphaQuality, 0.99999),
+          0
+        );
       }
     }
 
@@ -1261,7 +1302,9 @@ const WebMWriterClass = function (ArrayBufferDataStream, BlobBuffer) {
         writeHeader();
       }
 
-      let keyframe = extractKeyframeFromWebP(renderAsWebP(frame, options.quality)),
+      let keyframe = extractKeyframeFromWebP(
+          renderAsWebP(frame, options.quality)
+        ),
         frameDuration,
         frameAlpha = null;
 
@@ -1285,7 +1328,9 @@ const WebMWriterClass = function (ArrayBufferDataStream, BlobBuffer) {
         frame: keyframe.frame,
         duration: frameDuration,
         alpha: frameAlpha
-          ? extractKeyframeFromWebP(renderAsWebP(frameAlpha, options.alphaQuality)).frame
+          ? extractKeyframeFromWebP(
+              renderAsWebP(frameAlpha, options.alphaQuality)
+            ).frame
           : null
       });
     };

--- a/packages/create-mechanic/checkVersion.js
+++ b/packages/create-mechanic/checkVersion.js
@@ -3,7 +3,7 @@ const getPackageJson = require("package-json");
 const currentPkgJson = require("./package.json");
 const semver = require("semver");
 const {
-  spinners: { mechanicSpinner: spinner },
+  spinners: { mechanicSpinner: spinner }
 } = require("@mechanic-design/utils");
 
 const getLatestCommand = "npm init mechanic@latest";
@@ -33,5 +33,5 @@ const checkVersion = async () => {
 };
 
 module.exports = {
-  checkVersion,
+  checkVersion
 };

--- a/packages/create-mechanic/function-examples/business-card-generator/index.js
+++ b/packages/create-mechanic/function-examples/business-card-generator/index.js
@@ -12,7 +12,7 @@ export const handler = ({ inputs, mechanic }) => {
     company,
     name,
     email,
-    phone,
+    phone
   } = inputs;
 
   const margin = width / 18;
@@ -113,26 +113,26 @@ export const handler = ({ inputs, mechanic }) => {
 export const inputs = {
   width: {
     type: "number",
-    default: 850,
+    default: 850
   },
   height: {
     type: "number",
-    default: 550,
+    default: 550
   },
   backgroundColor: {
     type: "color",
     model: "hex",
-    default: "#FDD7D1",
+    default: "#FDD7D1"
   },
   colorOne: {
     type: "color",
     model: "hex",
-    default: "#E94225",
+    default: "#E94225"
   },
   colorTwo: {
     type: "color",
     model: "hex",
-    default: "#002EBB",
+    default: "#002EBB"
   },
   fontScale: {
     type: "number",
@@ -140,26 +140,26 @@ export const inputs = {
     slider: true,
     min: 0.1,
     max: 3,
-    step: 0.01,
+    step: 0.01
   },
   company: {
     type: "text",
-    default: "MECHANIC",
+    default: "MECHANIC"
   },
   name: {
     type: "text",
-    default: "Martin Bravo",
+    default: "Martin Bravo"
   },
   email: {
     type: "text",
-    default: "martin@mechanic.design",
+    default: "martin@mechanic.design"
   },
   phone: {
     type: "text",
-    default: "+1 999 999 9999",
-  },
+    default: "+1 999 999 9999"
+  }
 };
 
 export const settings = {
-  engine: require("@mechanic-design/engine-react"),
+  engine: require("@mechanic-design/engine-react")
 };

--- a/packages/create-mechanic/function-examples/index.js
+++ b/packages/create-mechanic/function-examples/index.js
@@ -2,18 +2,18 @@ const options = [
   {
     name: "Business Card Generator",
     type: "SVG",
-    dir: "business-card-generator",
+    dir: "business-card-generator"
   },
   {
     name: "Instagram Story Generator",
     type: "SVG",
-    dir: "instagram-story-generator",
+    dir: "instagram-story-generator"
   },
   {
     name: "Poster Generator",
     type: "Canvas",
-    dir: "poster-generator",
-  },
+    dir: "poster-generator"
+  }
 ];
 
 module.exports = options.reduce((acc, cur) => {

--- a/packages/create-mechanic/function-examples/instagram-story-generator/Circle.js
+++ b/packages/create-mechanic/function-examples/instagram-story-generator/Circle.js
@@ -8,7 +8,7 @@ export const Circle = ({
   minRadius,
   maxRadius,
   colorOne,
-  colorTwo,
+  colorTwo
 }) => {
   const x = useRef(minX + Math.random() * maxX - minX);
   const y = useRef(minY + Math.random() * (maxY - minY));

--- a/packages/create-mechanic/function-examples/instagram-story-generator/index.js
+++ b/packages/create-mechanic/function-examples/instagram-story-generator/index.js
@@ -15,7 +15,7 @@ export const handler = ({ inputs, mechanic }) => {
     text,
     minRadius,
     maxRadius,
-    duration,
+    duration
   } = inputs;
 
   // stuff needed for the looping
@@ -88,27 +88,27 @@ export const handler = ({ inputs, mechanic }) => {
 export const inputs = {
   width: {
     type: "number",
-    default: 1080,
+    default: 1080
   },
   height: {
     type: "number",
-    default: 1920,
+    default: 1920
   },
   backgroundColor: {
     type: "color",
     model: "hex",
-    default: "#FDD7D1",
+    default: "#FDD7D1"
   },
 
   colorOne: {
     type: "color",
     model: "hex",
-    default: "#E94225",
+    default: "#E94225"
   },
   colorTwo: {
     type: "color",
     model: "hex",
-    default: "#002EBB",
+    default: "#002EBB"
   },
   fontScale: {
     label: "Font Scale (%)",
@@ -116,11 +116,11 @@ export const inputs = {
     default: 100,
     slider: true,
     min: 5,
-    max: 200,
+    max: 200
   },
   text: {
     type: "text",
-    default: "TURN YOUR DESIGN RULES INTO DESIGN TOOLS",
+    default: "TURN YOUR DESIGN RULES INTO DESIGN TOOLS"
   },
 
   minRadius: {
@@ -129,7 +129,7 @@ export const inputs = {
     default: 5,
     min: 0,
     max: 200,
-    slider: true,
+    slider: true
   },
   maxRadius: {
     label: "Max Radius (% of width)",
@@ -137,16 +137,16 @@ export const inputs = {
     default: 10,
     min: 0,
     max: 200,
-    slider: true,
+    slider: true
   },
   duration: {
     label: "Duration (seconds)",
     type: "number",
-    default: 20,
-  },
+    default: 20
+  }
 };
 
 export const settings = {
   engine: require("@mechanic-design/engine-react"),
-  animated: true,
+  animated: true
 };

--- a/packages/create-mechanic/function-examples/instagram-story-generator/utils.js
+++ b/packages/create-mechanic/function-examples/instagram-story-generator/utils.js
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-export const useDrawLoop = (isPlaying) => {
+export const useDrawLoop = isPlaying => {
   const raf = useRef();
   const [frameCount, setFrameCount] = useState(0);
 
@@ -12,7 +12,7 @@ export const useDrawLoop = (isPlaying) => {
     }
 
     const draw = () => {
-      setFrameCount((cur) => cur + 1);
+      setFrameCount(cur => cur + 1);
       raf.current = requestAnimationFrame(draw);
     };
 

--- a/packages/create-mechanic/function-examples/poster-generator/index.js
+++ b/packages/create-mechanic/function-examples/poster-generator/index.js
@@ -7,7 +7,7 @@ import {
   getRandomSubsetSections,
   choice,
   flipCoin,
-  randInt,
+  randInt
 } from "./utils.js";
 
 import fontRegular from "./assets/PPObjectSans-Regular.otf";
@@ -70,7 +70,7 @@ export const handler = ({ inputs, mechanic, sketch }) => {
     const words = artistText.split(" ");
     sketch.textSize(element.baseSize * 0.8);
     sketch.textFont(objSansHeavySlanted);
-    const lengths = words.map((t) => sketch.textWidth(t));
+    const lengths = words.map(t => sketch.textWidth(t));
     element.length = Math.max(width / 3, ...lengths) + width / 20;
 
     element.startRow = choice(
@@ -265,7 +265,7 @@ export const handler = ({ inputs, mechanic, sketch }) => {
           ? randInt(freeSections.length - 2, freeSections.length)
           : freeSections.length
       ),
-      ...getRandomSubsetSections(usedSections, randInt(0, usedSections.length)),
+      ...getRandomSubsetSections(usedSections, randInt(0, usedSections.length))
     ];
 
     for (const section of sections) {
@@ -275,7 +275,7 @@ export const handler = ({ inputs, mechanic, sketch }) => {
       const offset = getIntersectionOffset(
         {
           startRow: row,
-          endRow: row + rowLength - 1,
+          endRow: row + rowLength - 1
         },
         [titleElement, datesElement]
       );
@@ -287,20 +287,20 @@ export const handler = ({ inputs, mechanic, sketch }) => {
           rx: offset,
           ry: rectY,
           rw: leftWidth - (columnLength + width / 20),
-          rh: rectHeight,
+          rh: rectHeight
         });
         drawRectangle({
           rx: width - columnLength,
           ry: rectY,
           rw: columnLength,
-          rh: rectHeight,
+          rh: rectHeight
         });
       } else {
         drawRectangle({
           rx: offset,
           ry: rectY,
           rw: leftWidth,
-          rh: rectHeight,
+          rh: rectHeight
         });
       }
     }
@@ -310,7 +310,7 @@ export const handler = ({ inputs, mechanic, sketch }) => {
         rx: width - columnLength,
         ry: 0,
         rw: width - columnLength,
-        rh: height,
+        rh: height
       });
     }
   };
@@ -356,51 +356,51 @@ export const handler = ({ inputs, mechanic, sketch }) => {
 export const inputs = {
   dates: {
     type: "text",
-    default: "Sept 9 – Oct 30, 2021",
+    default: "Sept 9 – Oct 30, 2021"
   },
   location: {
     type: "text",
-    default: "Jack Shainman Gallery",
+    default: "Jack Shainman Gallery"
   },
   artist: {
     type: "text",
-    default: "Tyler Mitchell",
+    default: "Tyler Mitchell"
   },
   title: {
     type: "text",
-    default: "Dreaming in Real Time",
+    default: "Dreaming in Real Time"
   },
   image: {
-    type: "image",
+    type: "image"
   },
   color: {
     type: "color",
     default: "#E94225",
-    model: "hex",
+    model: "hex"
   },
   width: {
     type: "number",
     default: 500,
-    editable: false,
+    editable: false
   },
   height: {
     type: "number",
     default: 600,
-    editable: false,
-  },
+    editable: false
+  }
 };
 
 export const presets = {
   x2: {
     width: 1000,
-    height: 1200,
+    height: 1200
   },
   x4: {
     width: 1500,
-    height: 1800,
-  },
+    height: 1800
+  }
 };
 
 export const settings = {
-  engine: require("@mechanic-design/engine-p5"),
+  engine: require("@mechanic-design/engine-p5")
 };

--- a/packages/create-mechanic/function-examples/poster-generator/utils.js
+++ b/packages/create-mechanic/function-examples/poster-generator/utils.js
@@ -16,10 +16,10 @@ export const getSections = (availableRows, filter = 0) => {
     lastRow = row;
   }
   sections.push([lastRow - (counter - 1), counter]);
-  return filter > 0 ? sections.filter((s) => s[1] > filter) : sections;
+  return filter > 0 ? sections.filter(s => s[1] > filter) : sections;
 };
 
-export const choice = (values) => {
+export const choice = values => {
   const index = Math.floor(Math.random() * values.length);
   return values[index];
 };
@@ -60,7 +60,7 @@ export const removeRowsUsedByElement = (availableRows, element) => {
   }
 };
 
-export const getRowsFromElements = (elements) => {
+export const getRowsFromElements = elements => {
   const rows = new Set();
   for (const element of elements) {
     for (let row = element.startRow; row <= element.endRow; row++) {

--- a/packages/create-mechanic/function-templates/canvas-image/index.js
+++ b/packages/create-mechanic/function-templates/canvas-image/index.js
@@ -43,46 +43,46 @@ export const handler = ({ inputs, mechanic }) => {
 export const inputs = {
   width: {
     type: "number",
-    default: 400,
+    default: 400
   },
   height: {
     type: "number",
-    default: 300,
+    default: 300
   },
   text: {
     type: "text",
-    default: "mechanic",
+    default: "mechanic"
   },
   color1: {
     type: "color",
     model: "hex",
-    default: "#E94225",
+    default: "#E94225"
   },
   color2: {
     type: "color",
     model: "hex",
-    default: "#002EBB",
+    default: "#002EBB"
   },
   radiusPercentage: {
     type: "number",
     default: 40,
     min: 0,
     max: 100,
-    slider: true,
-  },
+    slider: true
+  }
 };
 
 export const presets = {
   medium: {
     width: 800,
-    height: 600,
+    height: 600
   },
   large: {
     width: 1600,
-    height: 1200,
-  },
+    height: 1200
+  }
 };
 
 export const settings = {
-  engine: require("@mechanic-design/engine-canvas"),
+  engine: require("@mechanic-design/engine-canvas")
 };

--- a/packages/create-mechanic/function-templates/canvas-video/index.js
+++ b/packages/create-mechanic/function-templates/canvas-video/index.js
@@ -54,51 +54,51 @@ export const handler = async ({ inputs, mechanic }) => {
 export const inputs = {
   width: {
     type: "number",
-    default: 400,
+    default: 400
   },
   height: {
     type: "number",
-    default: 300,
+    default: 300
   },
   text: {
     type: "text",
-    default: "mechanic",
+    default: "mechanic"
   },
   color1: {
     type: "color",
     model: "hex",
-    default: "#E94225",
+    default: "#E94225"
   },
   color2: {
     type: "color",
     model: "hex",
-    default: "#002EBB",
+    default: "#002EBB"
   },
   radiusPercentage: {
     type: "number",
     default: 40,
     min: 0,
     max: 100,
-    slider: true,
+    slider: true
   },
   turns: {
     type: "number",
-    default: 3,
-  },
+    default: 3
+  }
 };
 
 export const presets = {
   medium: {
     width: 800,
-    height: 600,
+    height: 600
   },
   large: {
     width: 1600,
-    height: 1200,
-  },
+    height: 1200
+  }
 };
 
 export const settings = {
   engine: require("@mechanic-design/engine-canvas"),
-  animated: true,
+  animated: true
 };

--- a/packages/create-mechanic/function-templates/d3-image/index.js
+++ b/packages/create-mechanic/function-templates/d3-image/index.js
@@ -7,38 +7,41 @@ export const handler = ({ inputs, mechanic }) => {
   const radius = ((height / 2) * radiusPercentage) / 100;
   const angle = Math.random() * 360;
 
-  const SVG = d3.create("svg")
+  const SVG = d3
+    .create("svg")
     .attr("width", width)
     .attr("height", height)
     .attr("viewBox", [0, 0, width, height])
     .attr("style", "max-width: 100%; height: auto; height: intrinsic;");
 
-  const arc1 = d3.arc()
+  const arc1 = d3
+    .arc()
     .innerRadius(0)
     .outerRadius(radius)
     .startAngle(0)
-    .endAngle(2*Math.PI/2);
+    .endAngle((2 * Math.PI) / 2);
 
-  const arc2 = d3.arc()
+  const arc2 = d3
+    .arc()
     .innerRadius(0)
     .outerRadius(radius)
-    .startAngle(2*Math.PI/2)
-    .endAngle(4*Math.PI/2);
+    .startAngle((2 * Math.PI) / 2)
+    .endAngle((4 * Math.PI) / 2);
 
   SVG.append("path")
     .attr("transform", `translate(${center[0]},${center[1]}), rotate(${angle})`)
     .attr("d", arc1)
-    .attr("fill", color1)
+    .attr("fill", color1);
 
   SVG.append("path")
     .attr("transform", `translate(${center[0]},${center[1]}), rotate(${angle})`)
     .attr("d", arc2)
-    .attr("fill", color2)
+    .attr("fill", color2);
 
   SVG.append("text")
     .attr("transform", `translate(${center[0]}, ${height - height / 20})`)
     .style("text-anchor", "middle")
-    .style("font-size", height/10)
+    .style("font-size", height / 10)
     .style("font-family", "sans-serif")
     .text(text);
 
@@ -48,46 +51,46 @@ export const handler = ({ inputs, mechanic }) => {
 export const inputs = {
   width: {
     type: "number",
-    default: 400,
+    default: 400
   },
   height: {
     type: "number",
-    default: 300,
+    default: 300
   },
   text: {
     type: "text",
-    default: "mechanic",
+    default: "mechanic"
   },
   color1: {
     type: "color",
     model: "hex",
-    default: "#E94225",
+    default: "#E94225"
   },
   color2: {
     type: "color",
     model: "hex",
-    default: "#002EBB",
+    default: "#002EBB"
   },
   radiusPercentage: {
     type: "number",
     default: 40,
     min: 0,
     max: 100,
-    slider: true,
-  },
+    slider: true
+  }
 };
 
 export const presets = {
   medium: {
     width: 800,
-    height: 600,
+    height: 600
   },
   large: {
     width: 1600,
-    height: 1200,
-  },
+    height: 1200
+  }
 };
 
 export const settings = {
-  engine: require("@mechanic-design/engine-svg"),
+  engine: require("@mechanic-design/engine-svg")
 };

--- a/packages/create-mechanic/function-templates/index.js
+++ b/packages/create-mechanic/function-templates/index.js
@@ -2,53 +2,53 @@ const options = [
   {
     name: "Vanilla JS Image",
     type: "Canvas",
-    dir: "canvas-image",
+    dir: "canvas-image"
   },
   {
     name: "Vanilla JS Video",
     type: "Canvas",
-    dir: "canvas-video",
+    dir: "canvas-video"
   },
   {
     name: "Vanilla JS Image",
     type: "SVG",
-    dir: "svg-image",
+    dir: "svg-image"
   },
   {
     name: "Vanilla JS Video",
     type: "SVG",
-    dir: "svg-video",
+    dir: "svg-video"
   },
   {
     name: "SVG.js Image",
     type: "SVG",
-    dir: "svgjs-image",
+    dir: "svgjs-image"
   },
   {
     name: "D3 Image",
     type: "SVG",
-    dir: "d3-image",
+    dir: "d3-image"
   },
   {
     name: "p5.js Image",
     type: "Canvas",
-    dir: "p5-image",
+    dir: "p5-image"
   },
   {
     name: "p5.js Video",
     type: "Canvas",
-    dir: "p5-video",
+    dir: "p5-video"
   },
   {
     name: "React Image",
     type: "SVG",
-    dir: "react-image",
+    dir: "react-image"
   },
   {
     name: "React Video",
     type: "SVG",
-    dir: "react-video",
-  },
+    dir: "react-video"
+  }
 ];
 
 module.exports = options.reduce((acc, cur) => {

--- a/packages/create-mechanic/function-templates/p5-image/index.js
+++ b/packages/create-mechanic/function-templates/p5-image/index.js
@@ -35,46 +35,46 @@ export const handler = ({ inputs, mechanic, sketch }) => {
 export const inputs = {
   width: {
     type: "number",
-    default: 400,
+    default: 400
   },
   height: {
     type: "number",
-    default: 300,
+    default: 300
   },
   text: {
     type: "text",
-    default: "mechanic",
+    default: "mechanic"
   },
   color1: {
     type: "color",
     model: "hex",
-    default: "#E94225",
+    default: "#E94225"
   },
   color2: {
     type: "color",
     model: "hex",
-    default: "#002EBB",
+    default: "#002EBB"
   },
   radiusPercentage: {
     type: "number",
     default: 40,
     min: 0,
     max: 100,
-    slider: true,
-  },
+    slider: true
+  }
 };
 
 export const presets = {
   medium: {
     width: 800,
-    height: 600,
+    height: 600
   },
   large: {
     width: 1600,
-    height: 1200,
-  },
+    height: 1200
+  }
 };
 
 export const settings = {
-  engine: require("@mechanic-design/engine-p5"),
+  engine: require("@mechanic-design/engine-p5")
 };

--- a/packages/create-mechanic/function-templates/p5-video/index.js
+++ b/packages/create-mechanic/function-templates/p5-video/index.js
@@ -42,51 +42,51 @@ export const handler = ({ inputs, mechanic, sketch }) => {
 export const inputs = {
   width: {
     type: "number",
-    default: 400,
+    default: 400
   },
   height: {
     type: "number",
-    default: 300,
+    default: 300
   },
   text: {
     type: "text",
-    default: "mechanic",
+    default: "mechanic"
   },
   color1: {
     type: "color",
     model: "hex",
-    default: "#E94225",
+    default: "#E94225"
   },
   color2: {
     type: "color",
     model: "hex",
-    default: "#002EBB",
+    default: "#002EBB"
   },
   radiusPercentage: {
     type: "number",
     default: 40,
     min: 0,
     max: 100,
-    slider: true,
+    slider: true
   },
   turns: {
     type: "number",
-    default: 3,
-  },
+    default: 3
+  }
 };
 
 export const presets = {
   medium: {
     width: 800,
-    height: 600,
+    height: 600
   },
   large: {
     width: 1600,
-    height: 1200,
-  },
+    height: 1200
+  }
 };
 
 export const settings = {
   engine: require("@mechanic-design/engine-p5"),
-  animated: true,
+  animated: true
 };

--- a/packages/create-mechanic/function-templates/react-image/index.js
+++ b/packages/create-mechanic/function-templates/react-image/index.js
@@ -17,19 +17,19 @@ export const handler = ({ inputs, mechanic }) => {
 export const inputs = {
   width: {
     type: "number",
-    default: 400,
+    default: 400
   },
   height: {
     type: "number",
-    default: 300,
+    default: 300
   },
   color: {
     type: "color",
     model: "hex",
-    default: "#E94225",
-  },
+    default: "#E94225"
+  }
 };
 
 export const settings = {
-  engine: require("@mechanic-design/engine-react"),
+  engine: require("@mechanic-design/engine-react")
 };

--- a/packages/create-mechanic/function-templates/react-video/index.js
+++ b/packages/create-mechanic/function-templates/react-video/index.js
@@ -55,56 +55,56 @@ export const handler = ({ inputs, mechanic }) => {
 export const inputs = {
   width: {
     type: "number",
-    default: 400,
+    default: 400
   },
   height: {
     type: "number",
-    default: 300,
+    default: 300
   },
   text: {
     type: "text",
-    default: "mechanic",
+    default: "mechanic"
   },
   color1: {
     type: "color",
     model: "hex",
-    default: "#E94225",
+    default: "#E94225"
   },
   color2: {
     type: "color",
     model: "hex",
-    default: "#002EBB",
+    default: "#002EBB"
   },
   radiusPercentage: {
     type: "number",
     default: 40,
     min: 0,
     max: 100,
-    slider: true,
+    slider: true
   },
   turns: {
     type: "number",
-    default: 3,
-  },
+    default: 3
+  }
 };
 
 export const presets = {
   medium: {
     width: 800,
-    height: 600,
+    height: 600
   },
   large: {
     width: 1600,
-    height: 1200,
-  },
+    height: 1200
+  }
 };
 
 export const settings = {
   engine: require("@mechanic-design/engine-react"),
-  animated: true,
+  animated: true
 };
 
-const useDrawLoop = (isPlaying) => {
+const useDrawLoop = isPlaying => {
   const raf = useRef();
   const [frameCount, setFrameCount] = useState(0);
 
@@ -116,7 +116,7 @@ const useDrawLoop = (isPlaying) => {
     }
 
     const draw = () => {
-      setFrameCount((cur) => cur + 1);
+      setFrameCount(cur => cur + 1);
       raf.current = requestAnimationFrame(draw);
     };
 

--- a/packages/create-mechanic/function-templates/svg-image/index.js
+++ b/packages/create-mechanic/function-templates/svg-image/index.js
@@ -38,46 +38,46 @@ export const handler = ({ inputs, mechanic }) => {
 export const inputs = {
   width: {
     type: "number",
-    default: 400,
+    default: 400
   },
   height: {
     type: "number",
-    default: 300,
+    default: 300
   },
   text: {
     type: "text",
-    default: "mechanic",
+    default: "mechanic"
   },
   color1: {
     type: "color",
     model: "hex",
-    default: "#E94225",
+    default: "#E94225"
   },
   color2: {
     type: "color",
     model: "hex",
-    default: "#002EBB",
+    default: "#002EBB"
   },
   radiusPercentage: {
     type: "number",
     default: 40,
     min: 0,
     max: 100,
-    slider: true,
-  },
+    slider: true
+  }
 };
 
 export const presets = {
   medium: {
     width: 800,
-    height: 600,
+    height: 600
   },
   large: {
     width: 1600,
-    height: 1200,
-  },
+    height: 1200
+  }
 };
 
 export const settings = {
-  engine: require("@mechanic-design/engine-svg"),
+  engine: require("@mechanic-design/engine-svg")
 };

--- a/packages/create-mechanic/function-templates/svg-video/index.js
+++ b/packages/create-mechanic/function-templates/svg-video/index.js
@@ -50,51 +50,51 @@ export const handler = ({ inputs, mechanic }) => {
 export const inputs = {
   width: {
     type: "number",
-    default: 400,
+    default: 400
   },
   height: {
     type: "number",
-    default: 300,
+    default: 300
   },
   text: {
     type: "text",
-    default: "mechanic",
+    default: "mechanic"
   },
   color1: {
     type: "color",
     model: "hex",
-    default: "#E94225",
+    default: "#E94225"
   },
   color2: {
     type: "color",
     model: "hex",
-    default: "#002EBB",
+    default: "#002EBB"
   },
   radiusPercentage: {
     type: "number",
     default: 40,
     min: 0,
     max: 100,
-    slider: true,
+    slider: true
   },
   turns: {
     type: "number",
-    default: 3,
-  },
+    default: 3
+  }
 };
 
 export const presets = {
   medium: {
     width: 800,
-    height: 600,
+    height: 600
   },
   large: {
     width: 1600,
-    height: 1200,
-  },
+    height: 1200
+  }
 };
 
 export const settings = {
   engine: require("@mechanic-design/engine-svg"),
-  animated: true,
+  animated: true
 };

--- a/packages/create-mechanic/function-templates/svgjs-image/index.js
+++ b/packages/create-mechanic/function-templates/svgjs-image/index.js
@@ -1,8 +1,12 @@
-import { SVG, extend as SVGextend, Element as SVGElement } from '@svgdotjs/svg.js'
+import {
+  SVG,
+  extend as SVGextend,
+  Element as SVGElement
+} from "@svgdotjs/svg.js";
 
 // This rawSVG was exported directly from Adobe illustrator, and can be replaced with any other SVG export!
-const rawSVG = '<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 90 90" ><defs></defs><path class="cls-1" d="M90,45A45,45,0,0,0,0,45Z"/></svg>'
-
+const rawSVG =
+  '<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 90 90" ><defs></defs><path class="cls-1" d="M90,45A45,45,0,0,0,0,45Z"/></svg>';
 
 export const handler = ({ inputs, mechanic }) => {
   const { width, height, text, color1, color2, radiusPercentage } = inputs;
@@ -11,26 +15,25 @@ export const handler = ({ inputs, mechanic }) => {
   const radius = Math.max(radiusPercentage / 100, 0.1);
   const angle = Math.random() * 360;
 
-  const draw = SVG().size(width, height)
-  const arcGroup = draw.group()
-  const arc1 = arcGroup.group().svg(rawSVG)
-  const arc2 = arcGroup.group().svg(rawSVG)
-  const textBox = draw.text(text)
+  const draw = SVG().size(width, height);
+  const arcGroup = draw.group();
+  const arc1 = arcGroup.group().svg(rawSVG);
+  const arc2 = arcGroup.group().svg(rawSVG);
+  const textBox = draw.text(text);
 
-  arc1.scale(radius)
-  .css({fill: color1})
+  arc1.scale(radius).css({ fill: color1 });
 
-  arc2.scale(radius)
-  .rotate(180, center)
-  .css({fill: color2})
+  arc2.scale(radius).rotate(180, center).css({ fill: color2 });
 
-  arcGroup.move(center[0] - center[0]*radius, center[1] - center[1]*radius)
-  .rotate(angle)
+  arcGroup
+    .move(center[0] - center[0] * radius, center[1] - center[1] * radius)
+    .rotate(angle);
 
-  textBox.move(center[0], height - height/20)
-  .font({ family: 'sans-serif', size: 36, anchor: 'middle'})
-  .fill({ color: '#000' })
-  .font({ size: 36 })
+  textBox
+    .move(center[0], height - height / 20)
+    .font({ family: "sans-serif", size: 36, anchor: "middle" })
+    .fill({ color: "#000" })
+    .font({ size: 36 });
 
   mechanic.done(draw.node.outerHTML);
 };
@@ -38,46 +41,46 @@ export const handler = ({ inputs, mechanic }) => {
 export const inputs = {
   width: {
     type: "number",
-    default: 400,
+    default: 400
   },
   height: {
     type: "number",
-    default: 300,
+    default: 300
   },
   text: {
     type: "text",
-    default: "mechanic",
+    default: "mechanic"
   },
   color1: {
     type: "color",
     model: "hex",
-    default: "#E94225",
+    default: "#E94225"
   },
   color2: {
     type: "color",
     model: "hex",
-    default: "#002EBB",
+    default: "#002EBB"
   },
   radiusPercentage: {
     type: "number",
     default: 40,
     min: 0,
     max: 100,
-    slider: true,
-  },
+    slider: true
+  }
 };
 
 export const presets = {
   medium: {
     width: 800,
-    height: 600,
+    height: 600
   },
   large: {
     width: 1600,
-    height: 1200,
-  },
+    height: 1200
+  }
 };
 
 export const settings = {
-  engine: require("@mechanic-design/engine-svg"),
+  engine: require("@mechanic-design/engine-svg")
 };

--- a/packages/create-mechanic/index.js
+++ b/packages/create-mechanic/index.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const inquirer = require("inquirer");
 const {
-  spinners: { mechanicSpinner: spinner },
+  spinners: { mechanicSpinner: spinner }
 } = require("@mechanic-design/utils");
 
 const content = require("./script-content");
@@ -12,22 +12,22 @@ const {
   installationMethodQuestion,
   generateProjectTemplate,
   installDependencies,
-  checkLockFile,
+  checkLockFile
 } = require("./new-project");
 const {
   baseExists,
   directoryExists,
   generateFunctionTemplate,
-  getFunctionQuestions,
+  getFunctionQuestions
 } = require("./new-function");
 
 const log = console.log;
 const logSuccess = spinner.succeed;
 const logFail = spinner.fail;
-const sleep = (ms = 1000) => new Promise((resolve) => setTimeout(resolve, ms));
+const sleep = (ms = 1000) => new Promise(resolve => setTimeout(resolve, ms));
 const nullishCoalescingOp = (arg1, arg2) => (arg1 != null ? arg1 : arg2);
 
-const askToInstall = async (projectName) => {
+const askToInstall = async projectName => {
   // Install dependencies in new project directory
   const { install } = await inquirer.prompt(confirmInstallQuestion);
   await sleep();
@@ -46,7 +46,7 @@ const askToInstall = async (projectName) => {
   return install;
 };
 
-const command = async (argv) => {
+const command = async argv => {
   const project = argv._[0];
   const template = argv.template || argv.t;
   const example = argv.example || argv.e;
@@ -84,7 +84,7 @@ const command = async (argv) => {
   const projectQuestion = getProjectQuestion({
     project,
     usesBase: typeOfBaseUsed,
-    base,
+    base
   });
   const answers = await inquirer.prompt(projectQuestion);
   await sleep();
@@ -110,7 +110,7 @@ const command = async (argv) => {
     // Generate new functions directory and design function files and prompt if necessary
     const functionQuestions = getFunctionQuestions({
       usesBase: typeOfBaseUsed,
-      base,
+      base
     });
     const functionAnswers = await inquirer.prompt(functionQuestions);
     await sleep();
@@ -137,7 +137,7 @@ const command = async (argv) => {
     await generateFunctionTemplate(projectName, {
       typeOfBaseUsed: usesBase,
       base: finalBase,
-      functionName,
+      functionName
     });
   }
 
@@ -154,18 +154,18 @@ const commandOptions = {
     alias: "t",
     type: "string",
     description:
-      "Use simple design functions we created to show how to use Mechanic with specific web technologies.",
+      "Use simple design functions we created to show how to use Mechanic with specific web technologies."
   },
   example: {
     alias: "e",
     type: "string",
     description:
-      "Use more complicated design functions we created to show how to use Mechanic to tackle some common use cases.",
-  },
+      "Use more complicated design functions we created to show how to use Mechanic to tackle some common use cases."
+  }
 };
 
 module.exports = {
   create: command,
   options: commandOptions,
-  askToInstall,
+  askToInstall
 };

--- a/packages/create-mechanic/new-function.js
+++ b/packages/create-mechanic/new-function.js
@@ -1,7 +1,7 @@
 const fs = require("fs-extra");
 const path = require("path");
 const {
-  spinners: { mechanicSpinner: spinner },
+  spinners: { mechanicSpinner: spinner }
 } = require("@mechanic-design/utils");
 
 const functionExampleOptions = require("./function-examples");
@@ -13,7 +13,7 @@ const log = console.log;
 // https://gist.github.com/lovasoa/8691344#gistcomment-3299018
 const walk = (dir, fileCallback, directoryCallback) => {
   const files = fs.readdirSync(dir);
-  files.forEach((file) => {
+  files.forEach(file => {
     const filepath = path.join(dir, file);
     const stats = fs.statSync(filepath);
     if (stats.isDirectory()) {
@@ -46,7 +46,7 @@ const baseExists = (typeOfBaseUsed, base) => {
   return false;
 };
 
-const directoryExists = async (dirPath) => await fs.pathExists(dirPath);
+const directoryExists = async dirPath => await fs.pathExists(dirPath);
 
 const getFunctionQuestions = (initialAnswers, config = {}) => [
   {
@@ -60,7 +60,7 @@ const getFunctionQuestions = (initialAnswers, config = {}) => [
         ? "Template"
         : null,
     choices: ["Template", "Example", "Neither"],
-    when: initialAnswers.noSkip || !initialAnswers.usesBase,
+    when: initialAnswers.noSkip || !initialAnswers.usesBase
   },
   {
     name: "template",
@@ -68,24 +68,22 @@ const getFunctionQuestions = (initialAnswers, config = {}) => [
     message: content.functionTemplateQuestion(config.isFirst),
     default:
       initialAnswers.usesBase === "template" ? initialAnswers.base : null,
-    choices: Object.values(functionTemplateOptions).map((option) => ({
+    choices: Object.values(functionTemplateOptions).map(option => ({
       name: `${option.name} (${option.type})`,
-      value: option.dir,
+      value: option.dir
     })),
-    when: (answers) =>
-      !initialAnswers.usesBase && answers.usesBase === "Template",
+    when: answers => !initialAnswers.usesBase && answers.usesBase === "Template"
   },
   {
     name: "example",
     type: "list",
     message: content.functionExampleQuestion(config.isFirst),
     default: initialAnswers.usesBase === "example" ? initialAnswers.base : null,
-    choices: Object.values(functionExampleOptions).map((option) => ({
+    choices: Object.values(functionExampleOptions).map(option => ({
       name: `${option.name} (${option.type})`,
-      value: option.dir,
+      value: option.dir
     })),
-    when: (answers) =>
-      !initialAnswers.usesBase && answers.usesBase === "Example",
+    when: answers => !initialAnswers.usesBase && answers.usesBase === "Example"
   },
   {
     name: "functionName",
@@ -94,14 +92,14 @@ const getFunctionQuestions = (initialAnswers, config = {}) => [
     default: initialAnswers.usesBase
       ? initialAnswers.base
       : initialAnswers.functionName || "my-function",
-    validate: async (functionName) => {
+    validate: async functionName => {
       const exists = await fs.pathExists(
         path.resolve(config.functionsPath || "functions", functionName)
       );
       return !exists ? true : content.functionNameExistsError;
     },
-    when: initialAnswers.noSkip || !initialAnswers.usesBase,
-  },
+    when: initialAnswers.noSkip || !initialAnswers.usesBase
+  }
 ];
 
 const generateFunctionTemplate = async (
@@ -161,7 +159,7 @@ const generateFunctionTemplate = async (
         path.join(directory, "package.json"),
         JSON.stringify(packageObj, null, 2)
       );
-    })(),
+    })()
   ]);
   // Copy all files in base dir
   copyDirAndContents(baseFunctionDir, newFunctionDir);
@@ -185,6 +183,6 @@ module.exports = {
     baseDoesNotExist: content.baseDoesNotExist,
     directoryAlreadyExist: content.directoryAlreadyExist,
     doneAndNextStepsMessage: content.newFunctionNextStepsMessage,
-    bye: content.bye,
-  },
+    bye: content.bye
+  }
 };

--- a/packages/create-mechanic/new-project.js
+++ b/packages/create-mechanic/new-project.js
@@ -2,7 +2,7 @@ const fs = require("fs-extra");
 const execa = require("execa");
 const path = require("path");
 const {
-  spinners: { mechanicSpinner: spinner },
+  spinners: { mechanicSpinner: spinner }
 } = require("@mechanic-design/utils");
 
 const content = require("./script-content");
@@ -10,7 +10,7 @@ const content = require("./script-content");
 const log = console.log;
 const projectTemplateDir = path.join(__dirname, "project-template");
 
-const getProjectQuestion = (initialAnswers) => [
+const getProjectQuestion = initialAnswers => [
   {
     name: "project",
     type: "input",
@@ -21,27 +21,27 @@ const getProjectQuestion = (initialAnswers) => [
     when:
       initialAnswers.noSkip ||
       (!initialAnswers.usesBase && !initialAnswers.project),
-    validate: async (project) => {
+    validate: async project => {
       const exists = await fs.pathExists(path.resolve(project));
       return !exists ? true : content.projectNameExistsError;
-    },
-  },
+    }
+  }
 ];
 const confirmDFQuestion = [
   {
     name: "confirmContinue",
     type: "confirm",
     message: content.confirmContinueQuestion,
-    default: true,
-  },
+    default: true
+  }
 ];
 const confirmInstallQuestion = [
   {
     name: "install",
     type: "confirm",
     message: content.confirmInstallQuestion,
-    default: true,
-  },
+    default: true
+  }
 ];
 
 const installationMethodQuestion = [
@@ -50,8 +50,8 @@ const installationMethodQuestion = [
     type: "list",
     message: content.installationMethodQuestion,
     default: "npm",
-    choices: ["npm", "yarn"],
-  },
+    choices: ["npm", "yarn"]
+  }
 ];
 
 const generateProjectTemplate = async (projectName, typeOfBaseUsed) => {
@@ -65,7 +65,7 @@ const generateProjectTemplate = async (projectName, typeOfBaseUsed) => {
   // Copying content promises
   await Promise.all([
     // Copy array of files that get duplicated without change
-    ...["mechanic.config.js", "README.md"].map((filename) =>
+    ...["mechanic.config.js", "README.md"].map(filename =>
       fs.copyFile(
         path.join(projectTemplateDir, filename),
         path.join(directory, filename.replace(/^_/, "."))
@@ -79,14 +79,14 @@ const generateProjectTemplate = async (projectName, typeOfBaseUsed) => {
       );
       const packageObj = {
         name: projectName, // Adds name of project
-        ...packageJson,
+        ...packageJson
       };
       // Write the resulting package
       await fs.writeFile(
         path.join(directory, "package.json"),
         JSON.stringify(packageObj, null, 2)
       );
-    })(),
+    })()
   ]);
 
   spinner.succeed(content.generateProjectSuccess(typeOfBaseUsed, projectName));
@@ -135,5 +135,5 @@ module.exports = {
   installationMethodQuestion,
   generateProjectTemplate,
   checkLockFile,
-  installDependencies,
+  installDependencies
 };

--- a/packages/create-mechanic/project-template/mechanic.config.js
+++ b/packages/create-mechanic/project-template/mechanic.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   hooks: [],
-  port: 3000,
+  port: 3000
 };

--- a/packages/create-mechanic/script-content.js
+++ b/packages/create-mechanic/script-content.js
@@ -1,6 +1,6 @@
 const {
   logo: { mechanic, mechanicInverse },
-  colors: { success, bgRed, bgBlue },
+  colors: { success, bgRed, bgBlue }
 } = require("@mechanic-design/utils");
 
 const mechanicPackage = "@mechanic-design/core";
@@ -22,7 +22,7 @@ Welcome to Mechanic!`,
     `Mechanic ${typeOfBaseUsed ? typeOfBaseUsed : "project"} ${success(
       projectName
     )} directory created!`,
-  projectContents: (dirPath) =>
+  projectContents: dirPath =>
     `It was created in the current working directory: ${dirPath}
 It contains the following files:
 > ${success("package.json")} (has all dependencies to use Mechanic)
@@ -79,9 +79,9 @@ ${bgBlue(
   functionNameExistsError:
     "Directory already exists. Enter name that doesn't exists.",
   generateFunctionStart: "Adding design function to project...",
-  generateFunctionSuccess: (functionName) =>
+  generateFunctionSuccess: functionName =>
     `Design function "${functionName}" added to project!`,
-  functionCreationDetails: (functionName) =>
+  functionCreationDetails: functionName =>
     `This just:
 > Created a folder inside functions/, called ${success(
       functionName
@@ -96,9 +96,9 @@ ${bgBlue(
     "Do you wish to install dependencies for your project right away?",
   installationMethodQuestion:
     "Do you wish to install dependencies using npm or yarn?",
-  installTry: (method) => `Trying with ${method}.`,
-  installSucceed: (method) => `Installed dependencies with ${method}.`,
-  installFailed: (method) =>
+  installTry: method => `Trying with ${method}.`,
+  installSucceed: method => `Installed dependencies with ${method}.`,
+  installFailed: method =>
     `Failed to install with ${method}. Try installing by yourself to check the issue.`,
   doneAndNextStepsMessage: (projectName, installation) => `
 Done! Mechanic project created at ${success(projectName)}
@@ -138,5 +138,5 @@ To start you now can run:${
       ? "\n> `npm run dev` or `yarn run dev`"
       : `\`${installation.installingMethod} run dev\``
   }
-  `,
+  `
 };

--- a/packages/create-mechanic/updateVersions.js
+++ b/packages/create-mechanic/updateVersions.js
@@ -23,7 +23,7 @@ const path = require("path");
   for (const directory of ["function-templates", "function-examples"]) {
     const bases = fs
       .readdirSync(path.join(__dirname, directory))
-      .filter((d) => d !== "index.js");
+      .filter(d => d !== "index.js");
 
     for (const base of bases) {
       const dependenciesPath = path.join(

--- a/packages/create/index.js
+++ b/packages/create/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 const {
-  colors: { success },
+  colors: { success }
 } = require("@mechanic-design/utils");
 
 console.warn(

--- a/packages/dsi-logo-maker/functions/fillAnimatedSVG/index.js
+++ b/packages/dsi-logo-maker/functions/fillAnimatedSVG/index.js
@@ -1,30 +1,30 @@
-import React, { useState, useEffect, useMemo } from 'react';
-import { getColors } from '../../utils/graphics';
+import React, { useState, useEffect, useMemo } from "react";
+import { getColors } from "../../utils/graphics";
 import {
   computeBaseBricks,
   computeBlockGeometry,
   precomputeBlocks,
   getIndexModule
-} from '../../utils/blocks';
-import { Unit } from '../../utils/blocks-components';
-import { useDrawLoop, useLoadedOpentypeFont } from '../../utils/hooks';
+} from "../../utils/blocks";
+import { Unit } from "../../utils/blocks-components";
+import { useDrawLoop, useLoadedOpentypeFont } from "../../utils/hooks";
 
 export const handler = ({ inputs, mechanic }) => {
   const { width, height, logoWidth, logoRatio, duration, fontMode } = inputs;
   const { frame, done } = mechanic;
 
-  const [state, setState] = useState('loading');
+  const [state, setState] = useState("loading");
   const font = useLoadedOpentypeFont(fontMode);
-  const runtime = useDrawLoop(state === 'playing', duration);
+  const runtime = useDrawLoop(state === "playing", duration);
 
   const rows = 2;
   const cols = 13;
   const logoHeight = Math.floor((logoWidth / logoRatio) * rows);
-  const words = ['DESIGN', 'SYSTEMS', 'INTERNATIONAL'];
+  const words = ["DESIGN", "SYSTEMS", "INTERNATIONAL"];
 
   useEffect(() => {
-    if (state === 'loading' && font) {
-      setState('playing');
+    if (state === "loading" && font) {
+      setState("playing");
     }
   }, [font, state, setState]);
 
@@ -36,7 +36,7 @@ export const handler = ({ inputs, mechanic }) => {
       };
     }
 
-    let colors = getColors('Random Flag');
+    let colors = getColors("Random Flag");
     const blockGeometry = computeBlockGeometry(
       logoWidth,
       logoHeight,
@@ -61,7 +61,7 @@ export const handler = ({ inputs, mechanic }) => {
       position = { ...position };
       if (position.x + blockGeometry.width < width) {
         position.x += blockGeometry.width;
-        colors = getColors('Random Flag');
+        colors = getColors("Random Flag");
         brickOffset++;
       } else {
         position.x = position.x - width;
@@ -72,11 +72,11 @@ export const handler = ({ inputs, mechanic }) => {
   }, [font]);
 
   useEffect(() => {
-    if (state === 'playing') {
+    if (state === "playing") {
       if (runtime < duration) {
         frame();
       } else {
-        setState('stopped');
+        setState("stopped");
         done();
       }
     }
@@ -103,22 +103,22 @@ export const handler = ({ inputs, mechanic }) => {
 
 export const inputs = {
   width: {
-    type: 'number',
+    type: "number",
     default: 500,
     min: 100
   },
   height: {
-    type: 'number',
+    type: "number",
     default: 500,
     min: 100
   },
   logoWidth: {
-    type: 'number',
+    type: "number",
     default: 300,
     min: 10
   },
   logoRatio: {
-    type: 'number',
+    type: "number",
     default: 9,
     max: 20,
     slider: true,
@@ -126,22 +126,22 @@ export const inputs = {
     step: 1
   },
   duration: {
-    type: 'number',
+    type: "number",
     default: 5000,
     step: 500,
     min: 1000
   },
   fontMode: {
-    type: 'text',
+    type: "text",
     options: {
-      'F Grotesk Thin': 'FGroteskThin-Regular.otf',
-      'F Grotesk': 'FGrotesk-Regular.otf'
+      "F Grotesk Thin": "FGroteskThin-Regular.otf",
+      "F Grotesk": "FGrotesk-Regular.otf"
     },
-    default: 'F Grotesk Thin'
+    default: "F Grotesk Thin"
   }
 };
 
 export const settings = {
-  engine: require('@mechanic-design/engine-react'),
+  engine: require("@mechanic-design/engine-react"),
   animated: true
 };

--- a/packages/dsi-logo-maker/functions/fillCanvas/index.js
+++ b/packages/dsi-logo-maker/functions/fillCanvas/index.js
@@ -3,7 +3,7 @@ import {
   computeBaseBricks,
   computeBlockGeometry,
   precomputeBlocks,
-  getIndexModule,
+  getIndexModule
 } from "../../utils/blocks";
 import { loadOpentypeFont } from "../../utils/opentype";
 import { drawBlock } from "../../utils/blocks-canvas";
@@ -48,7 +48,7 @@ export const handler = async ({ inputs, mechanic }) => {
 
   ctx.save();
   ctx.clearRect(0, 0, width, height);
-  blockConfigs.forEach((blockConfig) => drawBlock(ctx, blockConfig));
+  blockConfigs.forEach(blockConfig => drawBlock(ctx, blockConfig));
   ctx.restore();
   mechanic.done(canvas);
 };
@@ -57,17 +57,17 @@ export const inputs = {
   width: {
     type: "number",
     default: 500,
-    min: 100,
+    min: 100
   },
   height: {
     type: "number",
     default: 500,
-    min: 100,
+    min: 100
   },
   logoWidth: {
     type: "number",
     default: 300,
-    min: 10,
+    min: 10
   },
   logoRatio: {
     type: "number",
@@ -75,33 +75,33 @@ export const inputs = {
     max: 20,
     slider: true,
     min: 6,
-    step: 1,
+    step: 1
   },
   fontMode: {
     type: "text",
     options: {
       "F Grotesk Thin": "FGroteskThin-Regular.otf",
-      "F Grotesk": "FGrotesk-Regular.otf",
+      "F Grotesk": "FGrotesk-Regular.otf"
     },
-    default: "F Grotesk Thin",
-  },
+    default: "F Grotesk Thin"
+  }
 };
 
 export const presets = {
   bigger: {
     width: 1000,
-    height: 1000,
+    height: 1000
   },
   panoramic: {
     width: 1000,
-    height: 250,
+    height: 250
   },
   long: {
     width: 500,
-    height: 1000,
-  },
+    height: 1000
+  }
 };
 
 export const settings = {
-  engine: require("@mechanic-design/engine-canvas"),
+  engine: require("@mechanic-design/engine-canvas")
 };

--- a/packages/dsi-logo-maker/functions/fillSVG/index.js
+++ b/packages/dsi-logo-maker/functions/fillSVG/index.js
@@ -4,7 +4,7 @@ import {
   computeBaseBricks,
   computeBlockGeometry,
   precomputeBlocks,
-  getIndexModule,
+  getIndexModule
 } from "../../utils/blocks";
 import { useLoadedOpentypeFont } from "../../utils/hooks";
 import { Block } from "../../utils/blocks-components";
@@ -71,17 +71,17 @@ export const inputs = {
   width: {
     type: "number",
     default: 500,
-    min: 100,
+    min: 100
   },
   height: {
     type: "number",
     default: 500,
-    min: 100,
+    min: 100
   },
   logoWidth: {
     type: "number",
     default: 300,
-    min: 10,
+    min: 10
   },
   logoRatio: {
     type: "number",
@@ -89,33 +89,33 @@ export const inputs = {
     max: 20,
     slider: true,
     min: 6,
-    step: 1,
+    step: 1
   },
   fontMode: {
     type: "text",
     options: {
       "F Grotesk Thin": "FGroteskThin-Regular.otf",
-      "F Grotesk": "FGrotesk-Regular.otf",
+      "F Grotesk": "FGrotesk-Regular.otf"
     },
-    default: "F Grotesk Thin",
-  },
+    default: "F Grotesk Thin"
+  }
 };
 
 export const presets = {
   bigger: {
     width: 1000,
-    height: 1000,
+    height: 1000
   },
   panoramic: {
     width: 1000,
-    height: 250,
+    height: 250
   },
   long: {
     width: 500,
-    height: 1000,
-  },
+    height: 1000
+  }
 };
 
 export const settings = {
-  engine: require("@mechanic-design/engine-react"),
+  engine: require("@mechanic-design/engine-react")
 };

--- a/packages/dsi-logo-maker/functions/flagBuilderCanvas/index.js
+++ b/packages/dsi-logo-maker/functions/flagBuilderCanvas/index.js
@@ -14,18 +14,18 @@ export const handler = ({ inputs, mechanic }) => {
     seedMode,
     seedText,
     seedForDistribution,
-    seedForOffset,
+    seedForOffset
   } = inputs;
 
   const colors = getColors(colorMode, flag, [
     firstColor,
     secondColor,
-    thirdColor,
+    thirdColor
   ]);
 
   const { seedDistribution, seedOffset } = buildSeeds(seedMode, seedText, {
     seedForDistribution,
-    seedForOffset,
+    seedForOffset
   });
 
   const blocks = buildBlocks({
@@ -33,7 +33,7 @@ export const handler = ({ inputs, mechanic }) => {
     height,
     seedDistribution,
     seedOffset,
-    colors,
+    colors
   });
 
   const canvas = document.createElement("canvas");
@@ -42,7 +42,7 @@ export const handler = ({ inputs, mechanic }) => {
 
   const ctx = canvas.getContext("2d");
 
-  blocks.forEach((block) => {
+  blocks.forEach(block => {
     ctx.fillStyle = block.color;
     ctx.fillRect(block.x, block.y, block.w, block.h);
   });
@@ -53,63 +53,63 @@ export const handler = ({ inputs, mechanic }) => {
 export const inputs = {
   width: {
     type: "number",
-    default: 600,
+    default: 600
   },
   height: {
     type: "number",
-    default: 400,
+    default: 400
   },
   seedMode: {
     type: "text",
     options: ["From Text", "Set Numbers"],
-    default: "From Text",
+    default: "From Text"
   },
   seedText: {
     type: "text",
     default: "Seed text",
-    editable: (inputs) => inputs.seedMode === "From Text",
+    editable: inputs => inputs.seedMode === "From Text"
   },
   seedForDistribution: {
     type: "number",
     default: 0,
-    editable: (inputs) => inputs.seedMode === "Set Numbers",
+    editable: inputs => inputs.seedMode === "Set Numbers"
   },
   seedForOffset: {
     type: "number",
     default: 0,
-    editable: (inputs) => inputs.seedMode === "Set Numbers",
+    editable: inputs => inputs.seedMode === "Set Numbers"
   },
   colorMode: {
     type: "text",
     options: ["Random Flag", "Pick Flag", "Custom Colors"],
-    default: "Random Flag",
+    default: "Random Flag"
   },
   flag: {
     type: "text",
     options: flagNames,
     default: flagNames[0],
-    editable: (inputs) => inputs.colorMode === "Pick Flag",
+    editable: inputs => inputs.colorMode === "Pick Flag"
   },
   firstColor: {
     type: "color",
     model: "hex",
     default: "#11457e",
-    editable: (inputs) => inputs.colorMode === "Custom Colors",
+    editable: inputs => inputs.colorMode === "Custom Colors"
   },
   secondColor: {
     type: "color",
     model: "hex",
     default: "#d7141a",
-    editable: (inputs) => inputs.colorMode === "Custom Colors",
+    editable: inputs => inputs.colorMode === "Custom Colors"
   },
   thirdColor: {
     type: "color",
     model: "hex",
     default: "#f1f1f1",
-    editable: (inputs) => inputs.colorMode === "Custom Colors",
-  },
+    editable: inputs => inputs.colorMode === "Custom Colors"
+  }
 };
 
 export const settings = {
-  engine: require("@mechanic-design/engine-canvas"),
+  engine: require("@mechanic-design/engine-canvas")
 };

--- a/packages/dsi-logo-maker/functions/flagBuilderSVG/index.js
+++ b/packages/dsi-logo-maker/functions/flagBuilderSVG/index.js
@@ -16,18 +16,18 @@ export const handler = ({ inputs, mechanic }) => {
     seedMode,
     seedText,
     seedForDistribution,
-    seedForOffset,
+    seedForOffset
   } = inputs;
 
   const colors = getColors(colorMode, flag, [
     firstColor,
     secondColor,
-    thirdColor,
+    thirdColor
   ]);
 
   const { seedDistribution, seedOffset } = buildSeeds(seedMode, seedText, {
     seedForDistribution,
-    seedForOffset,
+    seedForOffset
   });
 
   const blocks = useMemo(() => {
@@ -36,7 +36,7 @@ export const handler = ({ inputs, mechanic }) => {
       height,
       seedDistribution,
       seedOffset,
-      colors,
+      colors
     });
   }, [width, height, seedDistribution, seedOffset, colors]);
 
@@ -63,63 +63,63 @@ export const handler = ({ inputs, mechanic }) => {
 export const inputs = {
   width: {
     type: "number",
-    default: 600,
+    default: 600
   },
   height: {
     type: "number",
-    default: 400,
+    default: 400
   },
   seedMode: {
     type: "text",
     options: ["From Text", "Set Numbers"],
-    default: "From Text",
+    default: "From Text"
   },
   seedText: {
     type: "text",
     default: "Seed text",
-    editable: (inputs) => inputs.seedMode === "From Text",
+    editable: inputs => inputs.seedMode === "From Text"
   },
   seedForDistribution: {
     type: "number",
     default: 0,
-    editable: (inputs) => inputs.seedMode === "Set Numbers",
+    editable: inputs => inputs.seedMode === "Set Numbers"
   },
   seedForOffset: {
     type: "number",
     default: 0,
-    editable: (inputs) => inputs.seedMode === "Set Numbers",
+    editable: inputs => inputs.seedMode === "Set Numbers"
   },
   colorMode: {
     type: "text",
     options: ["Random Flag", "Pick Flag", "Custom Colors"],
-    default: "Random Flag",
+    default: "Random Flag"
   },
   flag: {
     type: "text",
     options: flagNames,
     default: flagNames[0],
-    editable: (inputs) => inputs.colorMode === "Pick Flag",
+    editable: inputs => inputs.colorMode === "Pick Flag"
   },
   firstColor: {
     type: "color",
     model: "hex",
     default: "#11457e",
-    editable: (inputs) => inputs.colorMode === "Custom Colors",
+    editable: inputs => inputs.colorMode === "Custom Colors"
   },
   secondColor: {
     type: "color",
     model: "hex",
     default: "#d7141a",
-    editable: (inputs) => inputs.colorMode === "Custom Colors",
+    editable: inputs => inputs.colorMode === "Custom Colors"
   },
   thirdColor: {
     type: "color",
     model: "hex",
     default: "#f1f1f1",
-    editable: (inputs) => inputs.colorMode === "Custom Colors",
-  },
+    editable: inputs => inputs.colorMode === "Custom Colors"
+  }
 };
 
 export const settings = {
-  engine: require("@mechanic-design/engine-react"),
+  engine: require("@mechanic-design/engine-react")
 };

--- a/packages/dsi-logo-maker/functions/logoAnimatedCanvas/index.js
+++ b/packages/dsi-logo-maker/functions/logoAnimatedCanvas/index.js
@@ -3,7 +3,7 @@ import {
   computeBaseBricks,
   computeBlockGeometry,
   precomputeBlocks,
-  getIndexModule,
+  getIndexModule
 } from "../../utils/blocks";
 import { loadOpentypeFont } from "../../utils/opentype";
 import { drawBlock } from "../../utils/blocks-canvas";
@@ -20,7 +20,7 @@ export const handler = async ({ inputs, mechanic }) => {
     thirdColor,
     offset,
     duration,
-    loops,
+    loops
   } = inputs;
 
   const rows = 2;
@@ -32,7 +32,7 @@ export const handler = async ({ inputs, mechanic }) => {
   const colors = getColors(colorMode, flag, [
     firstColor,
     secondColor,
-    thirdColor,
+    thirdColor
   ]);
   const blockGeometry = computeBlockGeometry(width, height, rows, cols);
   const baseBricks = computeBaseBricks(words, blockGeometry.fontSize, font);
@@ -62,7 +62,7 @@ export const handler = async ({ inputs, mechanic }) => {
   let internalOffset = 0;
   let progress = 0;
 
-  const animationHandler = (t) => {
+  const animationHandler = t => {
     const timestamp = t || new Date().getTime();
     if (!starttime) {
       starttime = timestamp;
@@ -88,7 +88,7 @@ export const handler = async ({ inputs, mechanic }) => {
 export const inputs = {
   width: {
     type: "number",
-    default: 500,
+    default: 500
   },
   ratio: {
     type: "number",
@@ -96,44 +96,44 @@ export const inputs = {
     max: 20,
     slider: true,
     min: 6,
-    step: 1,
+    step: 1
   },
   fontMode: {
     type: "text",
     options: {
       "F Grotesk Thin": "FGroteskThin-Regular.otf",
-      "F Grotesk": "FGrotesk-Regular.otf",
+      "F Grotesk": "FGrotesk-Regular.otf"
     },
-    default: "F Grotesk Thin",
+    default: "F Grotesk Thin"
   },
   colorMode: {
     type: "text",
     options: ["Random Flag", "Pick Flag", "Custom Colors"],
-    default: "Random Flag",
+    default: "Random Flag"
   },
   flag: {
     type: "text",
     options: flagNames,
     default: flagNames[0],
-    editable: (inputs) => inputs.colorMode === "Pick Flag",
+    editable: inputs => inputs.colorMode === "Pick Flag"
   },
   firstColor: {
     type: "color",
     model: "hex",
     default: "#11457e",
-    editable: (inputs) => inputs.colorMode === "Custom Colors",
+    editable: inputs => inputs.colorMode === "Custom Colors"
   },
   secondColor: {
     type: "color",
     model: "hex",
     default: "#d7141a",
-    editable: (inputs) => inputs.colorMode === "Custom Colors",
+    editable: inputs => inputs.colorMode === "Custom Colors"
   },
   thirdColor: {
     type: "color",
     model: "hex",
     default: "#f1f1f1",
-    editable: (inputs) => inputs.colorMode === "Custom Colors",
+    editable: inputs => inputs.colorMode === "Custom Colors"
   },
   offset: {
     type: "number",
@@ -141,34 +141,34 @@ export const inputs = {
     min: 0,
     max: 1,
     step: 0.05,
-    slider: true,
+    slider: true
   },
   duration: {
     type: "number",
     default: 5000,
     step: 500,
-    min: 1000,
+    min: 1000
   },
   loops: {
     type: "number",
     default: 4,
     min: 1,
-    step: 1,
-  },
+    step: 1
+  }
 };
 
 export const presets = {
   bigger: {
     width: 1000,
-    ratio: 9,
+    ratio: 9
   },
   biggerr: {
     width: 1500,
-    ratio: 9,
-  },
+    ratio: 9
+  }
 };
 
 export const settings = {
   engine: require("@mechanic-design/engine-canvas"),
-  animated: true,
+  animated: true
 };

--- a/packages/dsi-logo-maker/functions/logoAnimatedSVG/index.js
+++ b/packages/dsi-logo-maker/functions/logoAnimatedSVG/index.js
@@ -1,13 +1,13 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
-import { getColors, flagNames } from '../../utils/graphics';
+import React, { useState, useEffect, useRef, useMemo } from "react";
+import { getColors, flagNames } from "../../utils/graphics";
 import {
   computeBaseBricks,
   computeBlockGeometry,
   precomputeBlocks,
   getIndexModule
-} from '../../utils/blocks';
-import { Unit } from '../../utils/blocks-components';
-import { useDrawLoop, useLoadedOpentypeFont } from '../../utils/hooks';
+} from "../../utils/blocks";
+import { Unit } from "../../utils/blocks-components";
+import { useDrawLoop, useLoadedOpentypeFont } from "../../utils/hooks";
 
 export const handler = ({ inputs, mechanic }) => {
   const {
@@ -26,18 +26,18 @@ export const handler = ({ inputs, mechanic }) => {
   const { frame, done } = mechanic;
   const [internalOffset, setInternalOffset] = useState(0);
   const progress = useRef(0);
-  const [state, setState] = useState('loading');
+  const [state, setState] = useState("loading");
   const font = useLoadedOpentypeFont(fontMode);
-  const runtime = useDrawLoop(state === 'playing', duration);
+  const runtime = useDrawLoop(state === "playing", duration);
 
   const rows = 2;
   const cols = 13;
-  const words = ['DESIGN', 'SYSTEMS', 'INTERNATIONAL'];
+  const words = ["DESIGN", "SYSTEMS", "INTERNATIONAL"];
   const height = Math.floor((width / ratio) * rows);
 
   useEffect(() => {
-    if (state === 'loading' && font) {
-      setState('playing');
+    if (state === "loading" && font) {
+      setState("playing");
     }
   }, [font, state, setState]);
 
@@ -75,7 +75,7 @@ export const handler = ({ inputs, mechanic }) => {
   };
 
   useEffect(() => {
-    if (state === 'playing') {
+    if (state === "playing") {
       if (runtime < duration) {
         frame();
         let currentProgress = Math.floor(
@@ -83,10 +83,10 @@ export const handler = ({ inputs, mechanic }) => {
         );
         if (currentProgress > progress.current) {
           progress.current = currentProgress;
-          setInternalOffset((internalOffset) => internalOffset + 1);
+          setInternalOffset(internalOffset => internalOffset + 1);
         }
       } else {
-        setState('stopped');
+        setState("stopped");
         done();
       }
     }
@@ -111,12 +111,12 @@ export const handler = ({ inputs, mechanic }) => {
 
 export const inputs = {
   width: {
-    type: 'number',
+    type: "number",
     default: 500,
     min: 100
   },
   ratio: {
-    type: 'number',
+    type: "number",
     default: 9,
     max: 20,
     slider: true,
@@ -124,36 +124,36 @@ export const inputs = {
     step: 1
   },
   colorMode: {
-    type: 'text',
-    options: ['Random Flag', 'Pick Flag', 'Custom Colors'],
-    default: 'Random Flag'
+    type: "text",
+    options: ["Random Flag", "Pick Flag", "Custom Colors"],
+    default: "Random Flag"
   },
   flag: {
-    type: 'text',
+    type: "text",
     options: flagNames,
     default: flagNames[0],
-    editable: (inputs) => inputs.colorMode === 'Pick Flag'
+    editable: inputs => inputs.colorMode === "Pick Flag"
   },
   firstColor: {
-    type: 'color',
-    model: 'hex',
-    default: '#11457e',
-    editable: (inputs) => inputs.colorMode === 'Custom Colors'
+    type: "color",
+    model: "hex",
+    default: "#11457e",
+    editable: inputs => inputs.colorMode === "Custom Colors"
   },
   secondColor: {
-    type: 'color',
-    model: 'hex',
-    default: '#d7141a',
-    editable: (inputs) => inputs.colorMode === 'Custom Colors'
+    type: "color",
+    model: "hex",
+    default: "#d7141a",
+    editable: inputs => inputs.colorMode === "Custom Colors"
   },
   thirdColor: {
-    type: 'color',
-    model: 'hex',
-    default: '#f1f1f1',
-    editable: (inputs) => inputs.colorMode === 'Custom Colors'
+    type: "color",
+    model: "hex",
+    default: "#f1f1f1",
+    editable: inputs => inputs.colorMode === "Custom Colors"
   },
   offset: {
-    type: 'number',
+    type: "number",
     default: 0,
     min: 0,
     max: 1,
@@ -161,24 +161,24 @@ export const inputs = {
     slider: true
   },
   duration: {
-    type: 'number',
+    type: "number",
     default: 5000,
     step: 500,
     min: 1000
   },
   loops: {
-    type: 'number',
+    type: "number",
     default: 4,
     min: 1,
     step: 1
   },
   fontMode: {
-    type: 'text',
+    type: "text",
     options: {
-      'F Grotesk Thin': 'FGroteskThin-Regular.otf',
-      'F Grotesk': 'FGrotesk-Regular.otf'
+      "F Grotesk Thin": "FGroteskThin-Regular.otf",
+      "F Grotesk": "FGrotesk-Regular.otf"
     },
-    default: 'F Grotesk Thin'
+    default: "F Grotesk Thin"
   }
 };
 
@@ -194,6 +194,6 @@ export const presets = {
 };
 
 export const settings = {
-  engine: require('@mechanic-design/engine-react'),
+  engine: require("@mechanic-design/engine-react"),
   animated: true
 };

--- a/packages/dsi-logo-maker/functions/logoCanvas/index.js
+++ b/packages/dsi-logo-maker/functions/logoCanvas/index.js
@@ -2,7 +2,7 @@ import { getColors, flagNames } from "../../utils/graphics";
 import {
   computeBaseBricks,
   computeBlockGeometry,
-  computeBlock,
+  computeBlock
 } from "../../utils/blocks";
 import { loadOpentypeFont } from "../../utils/opentype";
 import { drawBlock } from "../../utils/blocks-canvas";
@@ -17,7 +17,7 @@ export const handler = async ({ inputs, mechanic }) => {
     firstColor,
     secondColor,
     thirdColor,
-    offset,
+    offset
   } = inputs;
 
   const rows = 2;
@@ -29,7 +29,7 @@ export const handler = async ({ inputs, mechanic }) => {
   const colors = getColors(colorMode, flag, [
     firstColor,
     secondColor,
-    thirdColor,
+    thirdColor
   ]);
   const blockGeometry = computeBlockGeometry(width, height, rows, cols);
   const baseBricks = computeBaseBricks(words, blockGeometry.fontSize, font);
@@ -60,7 +60,7 @@ export const inputs = {
   width: {
     type: "number",
     default: 500,
-    min: 100,
+    min: 100
   },
   ratio: {
     type: "number",
@@ -68,44 +68,44 @@ export const inputs = {
     max: 20,
     slider: true,
     min: 6,
-    step: 1,
+    step: 1
   },
   fontMode: {
     type: "text",
     options: {
       "F Grotesk Thin": "FGroteskThin-Regular.otf",
-      "F Grotesk": "FGrotesk-Regular.otf",
+      "F Grotesk": "FGrotesk-Regular.otf"
     },
-    default: "F Grotesk Thin",
+    default: "F Grotesk Thin"
   },
   colorMode: {
     type: "text",
     options: ["Random Flag", "Pick Flag", "Custom Colors"],
-    default: "Random Flag",
+    default: "Random Flag"
   },
   flag: {
     type: "text",
     options: flagNames,
     default: flagNames[0],
-    editable: (inputs) => inputs.colorMode === "Pick Flag",
+    editable: inputs => inputs.colorMode === "Pick Flag"
   },
   firstColor: {
     type: "color",
     model: "hex",
     default: "#11457e",
-    editable: (inputs) => inputs.colorMode === "Custom Colors",
+    editable: inputs => inputs.colorMode === "Custom Colors"
   },
   secondColor: {
     type: "color",
     model: "hex",
     default: "#d7141a",
-    editable: (inputs) => inputs.colorMode === "Custom Colors",
+    editable: inputs => inputs.colorMode === "Custom Colors"
   },
   thirdColor: {
     type: "color",
     model: "hex",
     default: "#f1f1f1",
-    editable: (inputs) => inputs.colorMode === "Custom Colors",
+    editable: inputs => inputs.colorMode === "Custom Colors"
   },
   offset: {
     type: "number",
@@ -113,21 +113,21 @@ export const inputs = {
     min: 0,
     max: 1,
     step: 0.02,
-    slider: true,
-  },
+    slider: true
+  }
 };
 
 export const presets = {
   bigger: {
     width: 1000,
-    ratio: 9,
+    ratio: 9
   },
   evenBigger: {
     width: 1500,
-    ratio: 9,
-  },
+    ratio: 9
+  }
 };
 
 export const settings = {
-  engine: require("@mechanic-design/engine-canvas"),
+  engine: require("@mechanic-design/engine-canvas")
 };

--- a/packages/dsi-logo-maker/functions/logoSVG/index.js
+++ b/packages/dsi-logo-maker/functions/logoSVG/index.js
@@ -3,7 +3,7 @@ import { getColors, flagNames } from "../../utils/graphics";
 import {
   computeBaseBricks,
   computeBlockGeometry,
-  computeBlock,
+  computeBlock
 } from "../../utils/blocks";
 import { useLoadedOpentypeFont } from "../../utils/hooks";
 import { Block } from "../../utils/blocks-components";
@@ -18,7 +18,7 @@ export const handler = ({ inputs, mechanic }) => {
     firstColor,
     secondColor,
     thirdColor,
-    offset,
+    offset
   } = inputs;
   const { done } = mechanic;
 
@@ -41,7 +41,7 @@ export const handler = ({ inputs, mechanic }) => {
   const colors = getColors(colorMode, flag, [
     firstColor,
     secondColor,
-    thirdColor,
+    thirdColor
   ]);
   const position = { x: 0, y: 0 };
   const blockGeometry = computeBlockGeometry(width, height, rows, cols);
@@ -63,7 +63,7 @@ export const inputs = {
   width: {
     type: "number",
     default: 500,
-    min: 100,
+    min: 100
   },
   ratio: {
     type: "number",
@@ -71,44 +71,44 @@ export const inputs = {
     max: 20,
     slider: true,
     min: 6,
-    step: 1,
+    step: 1
   },
   fontMode: {
     type: "text",
     options: {
       "F Grotesk Thin": "FGroteskThin-Regular.otf",
-      "F Grotesk": "FGrotesk-Regular.otf",
+      "F Grotesk": "FGrotesk-Regular.otf"
     },
-    default: "F Grotesk Thin",
+    default: "F Grotesk Thin"
   },
   colorMode: {
     type: "text",
     options: ["Random Flag", "Pick Flag", "Custom Colors"],
-    default: "Random Flag",
+    default: "Random Flag"
   },
   flag: {
     type: "text",
     options: flagNames,
     default: flagNames[0],
-    editable: (inputs) => inputs.colorMode === "Pick Flag",
+    editable: inputs => inputs.colorMode === "Pick Flag"
   },
   firstColor: {
     type: "color",
     model: "hex",
     default: "#11457e",
-    editable: (inputs) => inputs.colorMode === "Custom Colors",
+    editable: inputs => inputs.colorMode === "Custom Colors"
   },
   secondColor: {
     type: "color",
     model: "hex",
     default: "#d7141a",
-    editable: (inputs) => inputs.colorMode === "Custom Colors",
+    editable: inputs => inputs.colorMode === "Custom Colors"
   },
   thirdColor: {
     type: "color",
     model: "hex",
     default: "#f1f1f1",
-    editable: (inputs) => inputs.colorMode === "Custom Colors",
+    editable: inputs => inputs.colorMode === "Custom Colors"
   },
   offset: {
     type: "number",
@@ -116,21 +116,21 @@ export const inputs = {
     min: 0,
     max: 1,
     step: 0.02,
-    slider: true,
-  },
+    slider: true
+  }
 };
 
 export const presets = {
   bigger: {
     width: 1000,
-    ratio: 9,
+    ratio: 9
   },
   evenBigger: {
     width: 1500,
-    ratio: 9,
-  },
+    ratio: 9
+  }
 };
 
 export const settings = {
-  engine: require("@mechanic-design/engine-react"),
+  engine: require("@mechanic-design/engine-react")
 };

--- a/packages/dsi-logo-maker/functions/pinSVG/index.js
+++ b/packages/dsi-logo-maker/functions/pinSVG/index.js
@@ -3,7 +3,7 @@ import { getColors, flagNames } from "../../utils/graphics";
 import {
   computeBaseBricks,
   computeBlockGeometry,
-  computeBlock,
+  computeBlock
 } from "../../utils/blocks";
 import { useLoadedOpentypeFont } from "../../utils/hooks";
 import { Block } from "../../utils/blocks-components";
@@ -18,7 +18,7 @@ export const handler = ({ inputs, mechanic }) => {
     firstColor,
     secondColor,
     thirdColor,
-    offset,
+    offset
   } = inputs;
   const { done } = mechanic;
 
@@ -41,7 +41,7 @@ export const handler = ({ inputs, mechanic }) => {
   const colors = getColors(colorMode, flag, [
     firstColor,
     secondColor,
-    thirdColor,
+    thirdColor
   ]);
   const position = { x: 0, y: 0 };
   const blockGeometry = computeBlockGeometry(width, height, rows, cols);
@@ -92,7 +92,7 @@ export const inputs = {
   width: {
     type: "number",
     default: 500,
-    min: 100,
+    min: 100
   },
   ratio: {
     type: "number",
@@ -100,44 +100,44 @@ export const inputs = {
     max: 20,
     slider: true,
     min: 6,
-    step: 1,
+    step: 1
   },
   fontMode: {
     type: "text",
     options: {
       "F Grotesk Thin": "FGroteskThin-Regular.otf",
-      "F Grotesk": "FGrotesk-Regular.otf",
+      "F Grotesk": "FGrotesk-Regular.otf"
     },
-    default: "F Grotesk",
+    default: "F Grotesk"
   },
   colorMode: {
     type: "text",
     options: ["Random Flag", "Pick Flag", "Custom Colors"],
-    default: "Random Flag",
+    default: "Random Flag"
   },
   flag: {
     type: "text",
     options: flagNames,
     default: flagNames[0],
-    editable: (inputs) => inputs.colorMode === "Pick Flag",
+    editable: inputs => inputs.colorMode === "Pick Flag"
   },
   firstColor: {
     type: "color",
     model: "hex",
     default: "#11457e",
-    editable: (inputs) => inputs.colorMode === "Custom Colors",
+    editable: inputs => inputs.colorMode === "Custom Colors"
   },
   secondColor: {
     type: "color",
     model: "hex",
     default: "#d7141a",
-    editable: (inputs) => inputs.colorMode === "Custom Colors",
+    editable: inputs => inputs.colorMode === "Custom Colors"
   },
   thirdColor: {
     type: "color",
     model: "hex",
     default: "#f1f1f1",
-    editable: (inputs) => inputs.colorMode === "Custom Colors",
+    editable: inputs => inputs.colorMode === "Custom Colors"
   },
   offset: {
     type: "number",
@@ -145,21 +145,21 @@ export const inputs = {
     min: 0,
     max: 1,
     step: 0.02,
-    slider: true,
-  },
+    slider: true
+  }
 };
 
 export const presets = {
   big: {
     width: 1000,
-    ratio: 9,
+    ratio: 9
   },
   bigger: {
     width: 1500,
-    ratio: 9,
-  },
+    ratio: 9
+  }
 };
 
 export const settings = {
-  engine: require("@mechanic-design/engine-react"),
+  engine: require("@mechanic-design/engine-react")
 };

--- a/packages/dsi-logo-maker/functions/playCanvas/index.js
+++ b/packages/dsi-logo-maker/functions/playCanvas/index.js
@@ -3,7 +3,7 @@ import {
   computeBaseBricks,
   computeBlockGeometry,
   precomputeBlocks,
-  getIndexModule,
+  getIndexModule
 } from "../../utils/blocks";
 import { loadOpentypeFont } from "../../utils/opentype";
 import { drawBlock } from "../../utils/blocks-canvas";
@@ -25,7 +25,7 @@ export const handler = async ({ inputs, mechanic }) => {
       logoWidth: 150,
       x: 150,
       y: 0,
-      offset: 5,
+      offset: 5
     },
     {
       rows: 6,
@@ -34,7 +34,7 @@ export const handler = async ({ inputs, mechanic }) => {
       logoWidth: 100,
       x: 150,
       y: 34,
-      offset: 10,
+      offset: 10
     },
     {
       rows: 21,
@@ -43,7 +43,7 @@ export const handler = async ({ inputs, mechanic }) => {
       logoWidth: 50,
       x: 250,
       y: 34,
-      offset: 5,
+      offset: 5
     },
     {
       rows: 27,
@@ -52,7 +52,7 @@ export const handler = async ({ inputs, mechanic }) => {
       logoWidth: 50,
       x: 250,
       y: 150,
-      offset: 0,
+      offset: 0
     },
     {
       rows: 2,
@@ -61,7 +61,7 @@ export const handler = async ({ inputs, mechanic }) => {
       logoWidth: 250,
       x: 0,
       y: 175,
-      offset: 4,
+      offset: 4
     },
     {
       rows: 4,
@@ -70,9 +70,9 @@ export const handler = async ({ inputs, mechanic }) => {
       logoWidth: 175,
       x: 75,
       y: 230,
-      offset: 5,
+      offset: 5
     },
-    { rows: 3, cols: 5, logoRatio: 3, logoWidth: 75, x: 0, y: 230, offset: 0 },
+    { rows: 3, cols: 5, logoRatio: 3, logoWidth: 75, x: 0, y: 230, offset: 0 }
   ];
 
   for (const param of blockParams) {
@@ -102,7 +102,7 @@ export const handler = async ({ inputs, mechanic }) => {
 
   ctx.save();
   ctx.clearRect(0, 0, width, height);
-  blockConfigs.forEach((blockConfig) => drawBlock(ctx, blockConfig));
+  blockConfigs.forEach(blockConfig => drawBlock(ctx, blockConfig));
   ctx.restore();
   mechanic.done(canvas);
 };
@@ -111,34 +111,34 @@ export const inputs = {
   width: {
     type: "number",
     default: 300,
-    min: 100,
+    min: 100
   },
   height: {
     type: "number",
     default: 300,
-    min: 100,
+    min: 100
   },
   allSameColors: {
     type: "boolean",
-    default: true,
+    default: true
   },
   fontMode: {
     type: "text",
     options: {
       "F Grotesk Thin": "FGroteskThin-Regular.otf",
-      "F Grotesk": "FGrotesk-Regular.otf",
+      "F Grotesk": "FGrotesk-Regular.otf"
     },
-    default: "F Grotesk Thin",
-  },
+    default: "F Grotesk Thin"
+  }
 };
 
 export const presets = {
   bigger: {
     width: 500,
-    height: 500,
-  },
+    height: 500
+  }
 };
 
 export const settings = {
-  engine: require("@mechanic-design/engine-canvas"),
+  engine: require("@mechanic-design/engine-canvas")
 };

--- a/packages/dsi-logo-maker/functions/playSVG/index.js
+++ b/packages/dsi-logo-maker/functions/playSVG/index.js
@@ -4,7 +4,7 @@ import {
   computeBaseBricks,
   computeBlockGeometry,
   precomputeBlocks,
-  getIndexModule,
+  getIndexModule
 } from "../../utils/blocks";
 import { useLoadedOpentypeFont } from "../../utils/hooks";
 import { Block } from "../../utils/blocks-components";
@@ -37,7 +37,7 @@ export const handler = ({ inputs, mechanic }) => {
       logoWidth: 150,
       x: 150,
       y: 0,
-      offset: 5,
+      offset: 5
     },
     {
       rows: 6,
@@ -46,7 +46,7 @@ export const handler = ({ inputs, mechanic }) => {
       logoWidth: 100,
       x: 150,
       y: 34,
-      offset: 10,
+      offset: 10
     },
     {
       rows: 21,
@@ -55,7 +55,7 @@ export const handler = ({ inputs, mechanic }) => {
       logoWidth: 50,
       x: 250,
       y: 34,
-      offset: 5,
+      offset: 5
     },
     {
       rows: 27,
@@ -64,7 +64,7 @@ export const handler = ({ inputs, mechanic }) => {
       logoWidth: 50,
       x: 250,
       y: 150,
-      offset: 0,
+      offset: 0
     },
     {
       rows: 2,
@@ -73,7 +73,7 @@ export const handler = ({ inputs, mechanic }) => {
       logoWidth: 250,
       x: 0,
       y: 175,
-      offset: 4,
+      offset: 4
     },
     {
       rows: 4,
@@ -82,9 +82,9 @@ export const handler = ({ inputs, mechanic }) => {
       logoWidth: 175,
       x: 75,
       y: 230,
-      offset: 5,
+      offset: 5
     },
-    { rows: 3, cols: 5, logoRatio: 3, logoWidth: 75, x: 0, y: 230, offset: 0 },
+    { rows: 3, cols: 5, logoRatio: 3, logoWidth: 75, x: 0, y: 230, offset: 0 }
   ];
 
   for (const param of blockParams) {
@@ -125,34 +125,34 @@ export const inputs = {
   width: {
     type: "number",
     default: 300,
-    min: 100,
+    min: 100
   },
   height: {
     type: "number",
     default: 300,
-    min: 100,
+    min: 100
   },
   allSameColors: {
     type: "boolean",
-    default: true,
+    default: true
   },
   fontMode: {
     type: "text",
     options: {
       "F Grotesk Thin": "FGroteskThin-Regular.otf",
-      "F Grotesk": "FGrotesk-Regular.otf",
+      "F Grotesk": "FGrotesk-Regular.otf"
     },
-    default: "F Grotesk Thin",
-  },
+    default: "F Grotesk Thin"
+  }
 };
 
 export const presets = {
   bigger: {
     width: 500,
-    height: 500,
-  },
+    height: 500
+  }
 };
 
 export const settings = {
-  engine: require("@mechanic-design/engine-react"),
+  engine: require("@mechanic-design/engine-react")
 };

--- a/packages/dsi-logo-maker/functions/textAndImageCanvas/index.js
+++ b/packages/dsi-logo-maker/functions/textAndImageCanvas/index.js
@@ -2,7 +2,7 @@ import { getColors } from "../../utils/graphics";
 import {
   computeBaseBricks,
   computeBlockGeometry,
-  computeBlock,
+  computeBlock
 } from "../../utils/blocks";
 import { loadOpentypeFont } from "../../utils/opentype";
 import { drawBlock } from "../../utils/blocks-canvas";
@@ -17,10 +17,10 @@ export const handler = async ({ inputs, mechanic }) => {
     rows,
     colors: colorsString,
     offset,
-    image,
+    image
   } = inputs;
 
-  const words = text.split(" ").map((s) => s.toUpperCase());
+  const words = text.split(" ").map(s => s.toUpperCase());
   const colors = getColors("Custom Colors", null, colorsString.split(","));
   const height = Math.floor((width / ratio) * rows);
   const font = await loadOpentypeFont(fontMode);
@@ -60,7 +60,7 @@ export const inputs = {
   width: {
     type: "number",
     default: 500,
-    min: 100,
+    min: 100
   },
   ratio: {
     type: "number",
@@ -68,35 +68,35 @@ export const inputs = {
     max: 20,
     slider: true,
     min: 6,
-    step: 1,
+    step: 1
   },
   fontMode: {
     type: "text",
     options: {
       "F Grotesk Thin": "FGroteskThin-Regular.otf",
-      "F Grotesk": "FGrotesk-Regular.otf",
+      "F Grotesk": "FGrotesk-Regular.otf"
     },
-    default: "F Grotesk Thin",
+    default: "F Grotesk Thin"
   },
   text: {
     type: "text",
-    default: "Whatever you want",
+    default: "Whatever you want"
   },
   columns: {
     type: "number",
     default: 13,
     min: 1,
-    step: 1,
+    step: 1
   },
   rows: {
     type: "number",
     default: 2,
     min: 1,
-    step: 1,
+    step: 1
   },
   colors: {
     type: "text",
-    default: "#11457e,#d7141a,#f1f1f1",
+    default: "#11457e,#d7141a,#f1f1f1"
   },
   offset: {
     type: "number",
@@ -104,21 +104,21 @@ export const inputs = {
     min: 0,
     max: 1,
     step: 0.05,
-    slider: true,
+    slider: true
   },
   image: {
     type: "image",
-    multiple: false,
-  },
+    multiple: false
+  }
 };
 
 export const presets = {
   bigger: {
     width: 500,
-    ratio: 9,
-  },
+    ratio: 9
+  }
 };
 
 export const settings = {
-  engine: require("@mechanic-design/engine-canvas"),
+  engine: require("@mechanic-design/engine-canvas")
 };

--- a/packages/dsi-logo-maker/functions/textAndImageSVG/index.js
+++ b/packages/dsi-logo-maker/functions/textAndImageSVG/index.js
@@ -3,7 +3,7 @@ import { getColors } from "../../utils/graphics";
 import {
   computeBaseBricks,
   computeBlockGeometry,
-  computeBlock,
+  computeBlock
 } from "../../utils/blocks";
 import { useLoadedOpentypeFont } from "../../utils/hooks";
 import { Block } from "../../utils/blocks-components";
@@ -18,13 +18,13 @@ export const handler = ({ inputs, mechanic }) => {
     rows,
     colors: colorsString,
     offset,
-    image,
+    image
   } = inputs;
   const { done } = mechanic;
 
   const [href, setHref] = useState("");
 
-  const words = text.split(" ").map((s) => s.toUpperCase());
+  const words = text.split(" ").map(s => s.toUpperCase());
   const colors = getColors("Custom Colors", null, colorsString.split(","));
   const height = Math.floor((width / ratio) * rows);
   const font = useLoadedOpentypeFont(fontMode);
@@ -74,7 +74,7 @@ export const inputs = {
   width: {
     type: "number",
     default: 500,
-    min: 100,
+    min: 100
   },
   ratio: {
     type: "number",
@@ -82,35 +82,35 @@ export const inputs = {
     max: 20,
     slider: true,
     min: 6,
-    step: 1,
+    step: 1
   },
   fontMode: {
     type: "text",
     options: {
       "F Grotesk Thin": "FGroteskThin-Regular.otf",
-      "F Grotesk": "FGrotesk-Regular.otf",
+      "F Grotesk": "FGrotesk-Regular.otf"
     },
-    default: "F Grotesk Thin",
+    default: "F Grotesk Thin"
   },
   text: {
     type: "text",
-    default: "Whatever you want",
+    default: "Whatever you want"
   },
   columns: {
     type: "number",
     default: 13,
     min: 1,
-    step: 1,
+    step: 1
   },
   rows: {
     type: "number",
     default: 2,
     min: 1,
-    step: 1,
+    step: 1
   },
   colors: {
     type: "text",
-    default: "#11457e,#d7141a,#f1f1f1",
+    default: "#11457e,#d7141a,#f1f1f1"
   },
   offset: {
     type: "number",
@@ -118,21 +118,21 @@ export const inputs = {
     min: 0,
     max: 1,
     step: 0.05,
-    slider: true,
+    slider: true
   },
   image: {
     type: "image",
-    multiple: false,
-  },
+    multiple: false
+  }
 };
 
 export const presets = {
   bigger: {
     width: 500,
-    height: 500,
-  },
+    height: 500
+  }
 };
 
 export const settings = {
-  engine: require("@mechanic-design/engine-react"),
+  engine: require("@mechanic-design/engine-react")
 };

--- a/packages/dsi-logo-maker/functions/textAnimatedCanvas/index.js
+++ b/packages/dsi-logo-maker/functions/textAnimatedCanvas/index.js
@@ -3,7 +3,7 @@ import {
   computeBaseBricks,
   computeBlockGeometry,
   precomputeBlocks,
-  getIndexModule,
+  getIndexModule
 } from "../../utils/blocks";
 import { loadOpentypeFont } from "../../utils/opentype";
 import { drawBlock } from "../../utils/blocks-canvas";
@@ -19,10 +19,10 @@ export const handler = async ({ inputs, mechanic }) => {
     colors: colorsString,
     offset,
     duration,
-    loops,
+    loops
   } = inputs;
 
-  const words = text.split(" ").map((s) => s.toUpperCase());
+  const words = text.split(" ").map(s => s.toUpperCase());
   const height = Math.floor((width / ratio) * rows);
   const font = await loadOpentypeFont(fontMode);
 
@@ -56,7 +56,7 @@ export const handler = async ({ inputs, mechanic }) => {
   let internalOffset = 0;
   let progress = 0;
 
-  const animationHandler = (t) => {
+  const animationHandler = t => {
     const timestamp = t || new Date().getTime();
     if (!starttime) {
       starttime = timestamp;
@@ -83,7 +83,7 @@ export const inputs = {
   width: {
     type: "number",
     default: 500,
-    min: 100,
+    min: 100
   },
   ratio: {
     type: "number",
@@ -91,35 +91,35 @@ export const inputs = {
     max: 20,
     slider: true,
     min: 6,
-    step: 1,
+    step: 1
   },
   fontMode: {
     type: "text",
     options: {
       "F Grotesk Thin": "FGroteskThin-Regular.otf",
-      "F Grotesk": "FGrotesk-Regular.otf",
+      "F Grotesk": "FGrotesk-Regular.otf"
     },
-    default: "F Grotesk Thin",
+    default: "F Grotesk Thin"
   },
   text: {
     type: "text",
-    default: "Whatever you want",
+    default: "Whatever you want"
   },
   columns: {
     type: "number",
     default: 13,
     min: 1,
-    step: 1,
+    step: 1
   },
   rows: {
     type: "number",
     default: 2,
     min: 1,
-    step: 1,
+    step: 1
   },
   colors: {
     type: "text",
-    default: "#11457e,#d7141a,#f1f1f1",
+    default: "#11457e,#d7141a,#f1f1f1"
   },
   offset: {
     type: "number",
@@ -127,33 +127,33 @@ export const inputs = {
     min: 0,
     max: 1,
     step: 0.05,
-    slider: true,
+    slider: true
   },
   duration: {
     type: "number",
     default: 10000,
     min: 1000,
-    step: 500,
+    step: 500
   },
   loops: {
     type: "number",
     default: 4,
-    min: 1,
-  },
+    min: 1
+  }
 };
 
 export const presets = {
   bigger: {
     width: 500,
-    ratio: 9,
+    ratio: 9
   },
   evenBigger: {
     width: 500,
-    ratio: 9,
-  },
+    ratio: 9
+  }
 };
 
 export const settings = {
   engine: require("@mechanic-design/engine-canvas"),
-  animated: true,
+  animated: true
 };

--- a/packages/dsi-logo-maker/mechanic.config.js
+++ b/packages/dsi-logo-maker/mechanic.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   hooks: [],
-  port: 3000,
+  port: 3000
 };

--- a/packages/dsi-logo-maker/utils/blocks-canvas.js
+++ b/packages/dsi-logo-maker/utils/blocks-canvas.js
@@ -1,7 +1,7 @@
 export const drawBlock = (context, blockConfig, customStroke) => {
   const { position, block, colors } = blockConfig;
-  block.rows.forEach((row) =>
-    row.bricks.forEach((brick) => {
+  block.rows.forEach(row =>
+    row.bricks.forEach(brick => {
       const { x: xOffset, y: yOffset } = position;
       const { x: brickX, w, char, charX: brickCharX } = brick;
       const { background, blackOrWhite } = colors[brick.color % colors.length];

--- a/packages/dsi-logo-maker/utils/blocks-components.js
+++ b/packages/dsi-logo-maker/utils/blocks-components.js
@@ -1,5 +1,5 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { getIndexModule } from './blocks';
+import React, { useState, useEffect, useRef } from "react";
+import { getIndexModule } from "./blocks";
 
 const Brick = ({ brick, block, colors, stroke }) => {
   const { x, w, char, charX, isWordFirst, isWordLast } = brick;
@@ -59,7 +59,7 @@ export const Block = ({ position, block, colors, stroke }) => {
   const { rows } = block;
   return (
     <g transform={`translate(${x} ${y})`}>
-      {rows.map((row) => (
+      {rows.map(row => (
         <Row
           key={row.rowIndex}
           row={row}
@@ -87,7 +87,7 @@ export const Unit = ({
     let runtimeProgress = Math.floor(runtime * stepRate);
     if (runtimeProgress > progress.current) {
       progress.current = runtimeProgress;
-      setIndex((index) => getIndexModule(index + 1, blocks.length));
+      setIndex(index => getIndexModule(index + 1, blocks.length));
     }
   }, [runtime]);
 

--- a/packages/dsi-logo-maker/utils/blocks.js
+++ b/packages/dsi-logo-maker/utils/blocks.js
@@ -1,7 +1,7 @@
 export const computeBaseBricks = (words, fontSize, font) => {
   const bricks = [];
   let colori = 0;
-  words.forEach((word) => {
+  words.forEach(word => {
     for (let i = 0; i < word.length; i++) {
       const glyph = font.charToGlyph(word[i]);
       bricks.push({
@@ -10,7 +10,7 @@ export const computeBaseBricks = (words, fontSize, font) => {
         width: (glyph.advanceWidth / font.unitsPerEm) * fontSize,
         isWordFirst: i === 0,
         isWordLast: i === word.length - 1,
-        color: colori,
+        color: colori
       });
       if (i === word.length - 1) {
         colori++;
@@ -47,7 +47,7 @@ export const computeBlock = (blockGeometry, baseBricks, brickOffset) => {
   const block = {
     ...blockGeometry,
     brickIndex: getIndexModule(brickOffset, baseBricks.length),
-    rows: [],
+    rows: []
   };
 
   for (let rowIndex = 0; rowIndex < block.numberRows; rowIndex++) {
@@ -77,7 +77,7 @@ const computeRowGeometry = (bricks, rowIndex, blockGeometry) => {
     width - startGap - endGap - charsWidth - wordBreaks * wordGap * 2;
   return {
     rowIndex,
-    padding: remain / (bricks.length - 1) / 2,
+    padding: remain / (bricks.length - 1) / 2
   };
 };
 

--- a/packages/dsi-logo-maker/utils/flagBlocks.js
+++ b/packages/dsi-logo-maker/utils/flagBlocks.js
@@ -9,7 +9,7 @@ const colorDistributions = [
   [0.75, 0.25, 1],
   [0.5, 1, 0.5],
   [0.375, 0.875, 0.75],
-  [0.75, 0.375, 0.875],
+  [0.75, 0.375, 0.875]
 ];
 
 const offsets = [-0.5, -0.375, -0.25, 0, 0.25, 0.375, 0.5];
@@ -20,12 +20,12 @@ export const buildBlocks = ({
   height = 370,
   seedDistribution = 0,
   seedOffset = 0,
-  colors,
+  colors
 }) => {
   const colorDistribution = pickItemBySeed(
     colorDistributions,
     seedDistribution
-  ).map((d) => d * width);
+  ).map(d => d * width);
 
   const offset = pickItemBySeed(offsets, seedOffset) * width;
 
@@ -50,7 +50,7 @@ export const buildBlocks = ({
       } else {
         return {
           x: x + w,
-          y,
+          y
         };
       }
     };

--- a/packages/dsi-logo-maker/utils/flags.js
+++ b/packages/dsi-logo-maker/utils/flags.js
@@ -1,1442 +1,1442 @@
 export default [
-	{
-		name: 'Afghanistan',
-		colors: [
-			{ blackOrWhite: 'white', background: '#bf0000', text: '#bf0000' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' },
-			{ blackOrWhite: 'white', background: '#009900', text: '#009900' }
-		]
-	},
-	{
-		name: 'Albania',
-		colors: [
-			{ blackOrWhite: 'white', background: '#6f0f10', text: '#6f0f10' },
-			{ blackOrWhite: 'white', background: '#020000', text: '#020000' },
-			{ blackOrWhite: 'white', background: '#e41e20', text: '#e41e20' }
-		]
-	},
-	{
-		name: 'Algeria',
-		colors: [
-			{ blackOrWhite: 'white', background: '#d21034', text: '#d21034' },
-			{ blackOrWhite: 'white', background: '#006233', text: '#006233' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' }
-		]
-	},
-	{
-		name: 'Andorra',
-		colors: [
-			{ blackOrWhite: 'black', background: '#fdde00', text: '#e2c600' },
-			{ blackOrWhite: 'white', background: '#0018a8', text: '#0018a8' },
-			{ blackOrWhite: 'white', background: '#d0103a', text: '#d0103a' }
-		]
-	},
-	{
-		name: 'Angola',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f7d416', text: '#e6c514' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' }
-		]
-	},
-	{
-		name: 'Antigua and Barbuda',
-		colors: [
-			{ blackOrWhite: 'white', background: '#0072c6', text: '#0072c6' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' }
-		]
-	},
-	{
-		name: 'Argentina',
-		colors: [
-			{ blackOrWhite: 'black', background: '#d1e3f4', text: '#a5cbeb' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'black', background: '#74acdf', text: '#74acdf' }
-		]
-	},
-	{
-		name: 'Armenia',
-		colors: [
-			{ blackOrWhite: 'white', background: '#0033a0', text: '#0033a0' },
-			{ blackOrWhite: 'black', background: '#f2a800', text: '#f2a800' },
-			{ blackOrWhite: 'white', background: '#d90012', text: '#d90012' }
-		]
-	},
-	{
-		name: 'Australia',
-		colors: [
-			{ blackOrWhite: 'white', background: '#ff0101', text: '#ff0101' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#00008b', text: '#00008b' }
-		]
-	},
-	{
-		name: 'Azerbaijan',
-		colors: [
-			{ blackOrWhite: 'white', background: '#ed2939', text: '#ed2939' },
-			{ blackOrWhite: 'black', background: '#00b9e4', text: '#00b9e4' },
-			{ blackOrWhite: 'black', background: '#3f9c35', text: '#3f9c35' }
-		]
-	},
-	{
-		name: 'the Bahamas',
-		colors: [
-			{ blackOrWhite: 'black', background: '#fae042', text: '#dec73a' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' },
-			{ blackOrWhite: 'black', background: '#00abc9', text: '#00abc9' }
-		]
-	},
-	{
-		name: 'Bahrain',
-		colors: [
-			{ blackOrWhite: 'black', background: '#e78893', text: '#e78893' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' }
-		]
-	},
-	{
-		name: 'Bangladesh',
-		colors: [
-			{ blackOrWhite: 'white', background: '#6c4e48', text: '#6c4e48' },
-			{ blackOrWhite: 'white', background: '#f42a41', text: '#f42a41' },
-			{ blackOrWhite: 'white', background: '#006a4e', text: '#006a4e' }
-		]
-	},
-	{
-		name: 'Barbados',
-		colors: [
-			{ blackOrWhite: 'white', background: '#010100', text: '#010100' },
-			{ blackOrWhite: 'black', background: '#ffc726', text: '#f6bf00' },
-			{ blackOrWhite: 'white', background: '#00267f', text: '#00267f' }
-		]
-	},
-	{
-		name: 'Belarus',
-		colors: [
-			{ blackOrWhite: 'black', background: '#fceded', text: '#f3b8b8' },
-			{ blackOrWhite: 'black', background: '#4aa657', text: '#4aa657' },
-			{ blackOrWhite: 'white', background: '#c8313e', text: '#c8313e' }
-		]
-	},
-	{
-		name: 'Belize',
-		colors: [
-			{ blackOrWhite: 'black', background: '#d5dbd6', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' },
-			{ blackOrWhite: 'white', background: '#003f87', text: '#003f87' }
-		]
-	},
-	{
-		name: 'Bhutan',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'black', background: '#ff4e12', text: '#ff4e12' },
-			{ blackOrWhite: 'black', background: '#ffd520', text: '#ebc300' }
-		]
-	},
-	{
-		name: 'Bolivia',
-		colors: [
-			{ blackOrWhite: 'black', background: '#ffe000', text: '#e2c600' },
-			{ blackOrWhite: 'white', background: '#007934', text: '#007934' },
-			{ blackOrWhite: 'white', background: '#d52b1e', text: '#d52b1e' }
-		]
-	},
-	{
-		name: 'Bosnia and Herzegovina',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f0f0f8', text: '#c4c4e2' },
-			{ blackOrWhite: 'black', background: '#fecb00', text: '#f1c100' },
-			{ blackOrWhite: 'white', background: '#002395', text: '#002395' }
-		]
-	},
-	{
-		name: 'Botswana',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' },
-			{ blackOrWhite: 'black', background: '#75aadb', text: '#75aadb' }
-		]
-	},
-	{
-		name: 'Brazil',
-		colors: [
-			{ blackOrWhite: 'white', background: '#012876', text: '#012876' },
-			{ blackOrWhite: 'black', background: '#fddf00', text: '#e1c600' },
-			{ blackOrWhite: 'black', background: '#009b3a', text: '#009b3a' }
-		]
-	},
-	{
-		name: 'Brunei',
-		colors: [
-			{ blackOrWhite: 'white', background: '#010000', text: '#010000' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'black', background: '#f7e017', text: '#ddc813' }
-		]
-	},
-	{
-		name: 'Bulgaria',
-		colors: [
-			{ blackOrWhite: 'black', background: '#00966e', text: '#00966e' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#d62612', text: '#d62612' }
-		]
-	},
-	{
-		name: 'Burkina Faso',
-		colors: [
-			{ blackOrWhite: 'black', background: '#fcd116', text: '#ebc314' },
-			{ blackOrWhite: 'white', background: '#ef2b2d', text: '#ef2b2d' },
-			{ blackOrWhite: 'black', background: '#009e49', text: '#009e49' }
-		]
-	},
-	{
-		name: 'Burundi',
-		colors: [
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'black', background: '#1eb53a', text: '#1eb53a' }
-		]
-	},
-	{
-		name: 'Cambodia',
-		colors: [
-			{ blackOrWhite: 'black', background: '#a49fa0', text: '#a49fa0' },
-			{ blackOrWhite: 'white', background: '#e00025', text: '#e00025' },
-			{ blackOrWhite: 'white', background: '#032ea1', text: '#032ea1' }
-		]
-	},
-	{
-		name: 'Cameroon',
-		colors: [
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' },
-			{ blackOrWhite: 'white', background: '#007a5e', text: '#007a5e' },
-			{ blackOrWhite: 'black', background: '#fcd116', text: '#ebc314' }
-		]
-	},
-	{
-		name: 'Canada',
-		colors: [
-			{ blackOrWhite: 'black', background: '#ffd0d0', text: '#ffb3b3' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#ff0000', text: '#ff0000' }
-		]
-	},
-	{
-		name: 'Cape Verde',
-		colors: [
-			{ blackOrWhite: 'white', background: '#cf2027', text: '#cf2027' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#003893', text: '#003893' }
-		]
-	},
-	{
-		name: 'Central African Republic',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#289728', text: '#289728' },
-			{ blackOrWhite: 'black', background: '#ffce00', text: '#efc100' }
-		]
-	},
-	{
-		name: 'Chile',
-		colors: [
-			{ blackOrWhite: 'white', background: '#0039a6', text: '#0039a6' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#d52b1e', text: '#d52b1e' }
-		]
-	},
-	{
-		name: 'Comoros',
-		colors: [
-			{ blackOrWhite: 'white', background: '#3d8e33', text: '#3d8e33' },
-			{ blackOrWhite: 'black', background: '#ffc61e', text: '#f6be00' },
-			{ blackOrWhite: 'white', background: '#3a75c4', text: '#3a75c4' }
-		]
-	},
-	{
-		name: 'Democratic Republic of the Congo',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f7d518', text: '#e5c515' },
-			{ blackOrWhite: 'white', background: '#ce1021', text: '#ce1021' },
-			{ blackOrWhite: 'white', background: '#007fff', text: '#007fff' }
-		]
-	},
-	{
-		name: 'Congo',
-		colors: [
-			{ blackOrWhite: 'black', background: '#fbde4a', text: '#e0c641' },
-			{ blackOrWhite: 'white', background: '#009543', text: '#009543' },
-			{ blackOrWhite: 'white', background: '#dc241f', text: '#dc241f' }
-		]
-	},
-	{
-		name: 'Costa Rica',
-		colors: [
-			{ blackOrWhite: 'white', background: '#002b7f', text: '#002b7f' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' }
-		]
-	},
-	{
-		name: 'Croatia',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#171796', text: '#171796' },
-			{ blackOrWhite: 'white', background: '#ff0000', text: '#ff0000' }
-		]
-	},
-	{
-		name: 'Cuba',
-		colors: [
-			{ blackOrWhite: 'white', background: '#cf142b', text: '#cf142b' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#002a8f', text: '#002a8f' }
-		]
-	},
-	{
-		name: 'Cyprus',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f0e6d6', text: '#d8c4a0' },
-			{ blackOrWhite: 'black', background: '#d47600', text: '#d47600' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' }
-		]
-	},
-	{
-		name: 'Czech Republic',
-		colors: [
-			{ blackOrWhite: 'white', background: '#11457e', text: '#11457e' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#d7141a', text: '#d7141a' }
-		]
-	},
-	{
-		name: 'Djibouti',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'black', background: '#12ad2b', text: '#12ad2b' },
-			{ blackOrWhite: 'black', background: '#6ab2e7', text: '#6ab2e7' }
-		]
-	},
-	{
-		name: 'Dominica',
-		colors: [
-			{ blackOrWhite: 'black', background: '#fcd116', text: '#ebc314' },
-			{ blackOrWhite: 'white', background: '#d31c30', text: '#d31c30' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' }
-		]
-	},
-	{
-		name: 'Dominican Republic',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#002d62', text: '#002d62' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' }
-		]
-	},
-	{
-		name: 'Timor-Leste',
-		colors: [
-			{ blackOrWhite: 'black', background: '#ffc726', text: '#f6bf00' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' },
-			{ blackOrWhite: 'white', background: '#dc241f', text: '#dc241f' }
-		]
-	},
-	{
-		name: 'Ecuador',
-		colors: [
-			{ blackOrWhite: 'white', background: '#034ea2', text: '#034ea2' },
-			{ blackOrWhite: 'white', background: '#ed1c24', text: '#ed1c24' },
-			{ blackOrWhite: 'black', background: '#ffdd00', text: '#e4c600' }
-		]
-	},
-	{
-		name: 'Egypt',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' }
-		]
-	},
-	{
-		name: 'El Salvador',
-		colors: [
-			{ blackOrWhite: 'black', background: '#b0c2e5', text: '#b0c2e5' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#0f47af', text: '#0f47af' }
-		]
-	},
-	{
-		name: 'Equatorial Guinea',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'black', background: '#3e9a00', text: '#3e9a00' },
-			{ blackOrWhite: 'white', background: '#e32118', text: '#e32118' }
-		]
-	},
-	{
-		name: 'Eritrea',
-		colors: [
-			{ blackOrWhite: 'black', background: '#12ad2b', text: '#12ad2b' },
-			{ blackOrWhite: 'black', background: '#4189dd', text: '#4189dd' },
-			{ blackOrWhite: 'white', background: '#ea0437', text: '#ea0437' }
-		]
-	},
-	{
-		name: 'Estonia',
-		colors: [
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'black', background: '#4891d9', text: '#4891d9' }
-		]
-	},
-	{
-		name: 'Ethiopia',
-		colors: [
-			{ blackOrWhite: 'black', background: '#fbdd09', text: '#e2c607' },
-			{ blackOrWhite: 'white', background: '#da121a', text: '#da121a' },
-			{ blackOrWhite: 'white', background: '#078930', text: '#078930' }
-		]
-	},
-	{
-		name: 'Fiji',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#cf1129', text: '#cf1129' },
-			{ blackOrWhite: 'black', background: '#68bfe5', text: '#68bfe5' }
-		]
-	},
-	{
-		name: 'Finland',
-		colors: [
-			{ blackOrWhite: 'white', background: '#5c7eae', text: '#5c7eae' },
-			{ blackOrWhite: 'white', background: '#003580', text: '#003580' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' }
-		]
-	},
-	{
-		name: 'Gabon',
-		colors: [
-			{ blackOrWhite: 'black', background: '#fcd116', text: '#ebc314' },
-			{ blackOrWhite: 'black', background: '#009e60', text: '#009e60' },
-			{ blackOrWhite: 'white', background: '#3a75c4', text: '#3a75c4' }
-		]
-	},
-	{
-		name: 'the Gambia',
-		colors: [
-			{ blackOrWhite: 'white', background: '#0c1c8c', text: '#0c1c8c' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' },
-			{ blackOrWhite: 'white', background: '#3a7728', text: '#3a7728' }
-		]
-	},
-	{
-		name: 'Georgia',
-		colors: [
-			{ blackOrWhite: 'black', background: '#ff8e8e', text: '#ff8e8e' },
-			{ blackOrWhite: 'white', background: '#ff0000', text: '#ff0000' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' }
-		]
-	},
-	{
-		name: 'Germany',
-		colors: [
-			{ blackOrWhite: 'white', background: '#dd0000', text: '#dd0000' },
-			{ blackOrWhite: 'black', background: '#ffce00', text: '#efc100' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' }
-		]
-	},
-	{
-		name: 'Ghana',
-		colors: [
-			{ blackOrWhite: 'black', background: '#fcd116', text: '#ebc314' },
-			{ blackOrWhite: 'white', background: '#006b3f', text: '#006b3f' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' }
-		]
-	},
-	{
-		name: 'Greece',
-		colors: [
-			{ blackOrWhite: 'black', background: '#79a6d3', text: '#79a6d3' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#0d5eaf', text: '#0d5eaf' }
-		]
-	},
-	{
-		name: 'Grenada',
-		colors: [
-			{ blackOrWhite: 'white', background: '#007a5e', text: '#007a5e' },
-			{ blackOrWhite: 'black', background: '#fcd116', text: '#ebc314' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' }
-		]
-	},
-	{
-		name: 'Guatemala',
-		colors: [
-			{ blackOrWhite: 'black', background: '#c3ddf0', text: '#a1cce9' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'black', background: '#4997d0', text: '#4997d0' }
-		]
-	},
-	{
-		name: 'Guinea-Bissau',
-		colors: [
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' },
-			{ blackOrWhite: 'black', background: '#009e49', text: '#009e49' },
-			{ blackOrWhite: 'black', background: '#fcd116', text: '#ebc314' }
-		]
-	},
-	{
-		name: 'Guyana',
-		colors: [
-			{ blackOrWhite: 'black', background: '#fcd116', text: '#ebc314' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' },
-			{ blackOrWhite: 'black', background: '#009e49', text: '#009e49' }
-		]
-	},
-	{
-		name: 'Haiti',
-		colors: [
-			{ blackOrWhite: 'white', background: '#1d6d1f', text: '#1d6d1f' },
-			{ blackOrWhite: 'white', background: '#00209f', text: '#00209f' },
-			{ blackOrWhite: 'white', background: '#d21034', text: '#d21034' }
-		]
-	},
-	{
-		name: 'Honduras',
-		colors: [
-			{ blackOrWhite: 'black', background: '#aad0ef', text: '#a1ccee' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#0073cf', text: '#0073cf' }
-		]
-	},
-	{
-		name: 'Hungary',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#436f4d', text: '#436f4d' },
-			{ blackOrWhite: 'white', background: '#cd2a3e', text: '#cd2a3e' }
-		]
-	},
-	{
-		name: 'Iceland',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#d72828', text: '#d72828' },
-			{ blackOrWhite: 'white', background: '#003897', text: '#003897' }
-		]
-	},
-	{
-		name: 'India',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'black', background: '#ff9933', text: '#ff9933' },
-			{ blackOrWhite: 'white', background: '#128807', text: '#128807' }
-		]
-	},
-	{
-		name: 'Iran',
-		colors: [
-			{ blackOrWhite: 'black', background: '#239f40', text: '#239f40' },
-			{ blackOrWhite: 'white', background: '#da0101', text: '#da0101' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' }
-		]
-	},
-	{
-		name: 'Iraq',
-		colors: [
-			{ blackOrWhite: 'white', background: '#14844c', text: '#14844c' },
-			{ blackOrWhite: 'black', background: '#dcede5', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' }
-		]
-	},
-	{
-		name: 'Ireland',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'black', background: '#169b62', text: '#169b62' },
-			{ blackOrWhite: 'black', background: '#ff883e', text: '#ff883e' }
-		]
-	},
-	{
-		name: 'Israel',
-		colors: [
-			{ blackOrWhite: 'black', background: '#5f82d2', text: '#5f82d2' },
-			{ blackOrWhite: 'white', background: '#0038b8', text: '#0038b8' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' }
-		]
-	},
-	{
-		name: 'Jamaica',
-		colors: [
-			{ blackOrWhite: 'black', background: '#fed100', text: '#ecc200' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' },
-			{ blackOrWhite: 'black', background: '#009b3a', text: '#009b3a' }
-		]
-	},
-	{
-		name: 'Japan',
-		colors: [
-			{ blackOrWhite: 'white', background: '#d14f6e', text: '#d14f6e' },
-			{ blackOrWhite: 'white', background: '#bc002d', text: '#bc002d' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' }
-		]
-	},
-	{
-		name: 'Jordan',
-		colors: [
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' },
-			{ blackOrWhite: 'white', background: '#007a3d', text: '#007a3d' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' }
-		]
-	},
-	{
-		name: 'Kazakhstan',
-		colors: [
-			{ blackOrWhite: 'black', background: '#97bc59', text: '#97bc59' },
-			{ blackOrWhite: 'black', background: '#fac50f', text: '#f3c00e' },
-			{ blackOrWhite: 'black', background: '#00afca', text: '#00afca' }
-		]
-	},
-	{
-		name: 'Kenya',
-		colors: [
-			{ blackOrWhite: 'white', background: '#006600', text: '#006600' },
-			{ blackOrWhite: 'white', background: '#bb0000', text: '#bb0000' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' }
-		]
-	},
-	{
-		name: 'Kiribati',
-		colors: [
-			{ blackOrWhite: 'black', background: '#facf15', text: '#ebc313' },
-			{ blackOrWhite: 'black', background: '#ffebff', text: '#ffa9ff' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' }
-		]
-	},
-	{
-		name: 'North Korea',
-		colors: [
-			{ blackOrWhite: 'black', background: '#ffecec', text: '#ffb3b3' },
-			{ blackOrWhite: 'white', background: '#024fa2', text: '#024fa2' },
-			{ blackOrWhite: 'white', background: '#ed1c27', text: '#ed1c27' }
-		]
-	},
-	{
-		name: 'South Korea',
-		colors: [
-			{ blackOrWhite: 'white', background: '#c60c30', text: '#c60c30' },
-			{ blackOrWhite: 'white', background: '#013478', text: '#013478' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' }
-		]
-	},
-	{
-		name: 'Kuwait',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#007a3d', text: '#007a3d' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' }
-		]
-	},
-	{
-		name: 'Kyrgyzstan',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f58e14', text: '#f58e14' },
-			{ blackOrWhite: 'black', background: '#ffed00', text: '#d9c900' },
-			{ blackOrWhite: 'white', background: '#e8112d', text: '#e8112d' }
-		]
-	},
-	{
-		name: 'Laos',
-		colors: [
-			{ blackOrWhite: 'black', background: '#adffff', text: '#00dddd' },
-			{ blackOrWhite: 'white', background: '#002868', text: '#002868' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' }
-		]
-	},
-	{
-		name: 'Lebanon',
-		colors: [
-			{ blackOrWhite: 'black', background: '#01a652', text: '#01a652' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#ed1c24', text: '#ed1c24' }
-		]
-	},
-	{
-		name: 'Lesotho',
-		colors: [
-			{ blackOrWhite: 'white', background: '#00209f', text: '#00209f' },
-			{ blackOrWhite: 'white', background: '#009543', text: '#009543' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' }
-		]
-	},
-	{
-		name: 'Liberia',
-		colors: [
-			{ blackOrWhite: 'white', background: '#002868', text: '#002868' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#bf0a30', text: '#bf0a30' }
-		]
-	},
-	{
-		name: 'Libya',
-		colors: [
-			{ blackOrWhite: 'white', background: '#e70013', text: '#e70013' },
-			{ blackOrWhite: 'black', background: '#239e46', text: '#239e46' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' }
-		]
-	},
-	{
-		name: 'Liechtenstein',
-		colors: [
-			{ blackOrWhite: 'black', background: '#bea12e', text: '#bea12e' },
-			{ blackOrWhite: 'white', background: '#002b7f', text: '#002b7f' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' }
-		]
-	},
-	{
-		name: 'Lithuania',
-		colors: [
-			{ blackOrWhite: 'white', background: '#006a44', text: '#006a44' },
-			{ blackOrWhite: 'black', background: '#fdb913', text: '#fdb913' },
-			{ blackOrWhite: 'white', background: '#c1272d', text: '#c1272d' }
-		]
-	},
-	{
-		name: 'Luxembourg',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'black', background: '#00a1de', text: '#00a1de' },
-			{ blackOrWhite: 'white', background: '#ed2939', text: '#ed2939' }
-		]
-	},
-	{
-		name: 'Macedonia',
-		colors: [
-			{ blackOrWhite: 'white', background: '#dc3400', text: '#dc3400' },
-			{ blackOrWhite: 'black', background: '#ffe600', text: '#dec800' },
-			{ blackOrWhite: 'white', background: '#d20000', text: '#d20000' }
-		]
-	},
-	{
-		name: 'Malawi',
-		colors: [
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' },
-			{ blackOrWhite: 'black', background: '#339e35', text: '#339e35' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' }
-		]
-	},
-	{
-		name: 'Malaysia',
-		colors: [
-			{ blackOrWhite: 'white', background: '#010066', text: '#010066' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#cc0001', text: '#cc0001' }
-		]
-	},
-	{
-		name: 'Maldives',
-		colors: [
-			{ blackOrWhite: 'black', background: '#c9e4d5', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#007e3a', text: '#007e3a' },
-			{ blackOrWhite: 'white', background: '#d21034', text: '#d21034' }
-		]
-	},
-	{
-		name: 'Malta',
-		colors: [
-			{ blackOrWhite: 'black', background: '#a9a29c', text: '#a9a29c' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#cf142b', text: '#cf142b' }
-		]
-	},
-	{
-		name: 'Marshall Islands',
-		colors: [
-			{ blackOrWhite: 'black', background: '#dd7500', text: '#dd7500' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#003893', text: '#003893' }
-		]
-	},
-	{
-		name: 'Mauritania',
-		colors: [
-			{ blackOrWhite: 'white', background: '#477d25', text: '#477d25' },
-			{ blackOrWhite: 'black', background: '#ffc400', text: '#f7be00' },
-			{ blackOrWhite: 'white', background: '#006233', text: '#006233' }
-		]
-	},
-	{
-		name: 'Mauritius',
-		colors: [
-			{ blackOrWhite: 'black', background: '#00a551', text: '#00a551' },
-			{ blackOrWhite: 'white', background: '#ea2839', text: '#ea2839' },
-			{ blackOrWhite: 'white', background: '#1a206d', text: '#1a206d' }
-		]
-	},
-	{
-		name: 'Mexico',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#006847', text: '#006847' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' }
-		]
-	},
-	{
-		name: 'Moldova',
-		colors: [
-			{ blackOrWhite: 'black', background: '#ffd200', text: '#ecc200' },
-			{ blackOrWhite: 'white', background: '#0046ae', text: '#0046ae' },
-			{ blackOrWhite: 'white', background: '#cc092f', text: '#cc092f' }
-		]
-	},
-	{
-		name: 'Mongolia',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f9cf02', text: '#ebc302' },
-			{ blackOrWhite: 'white', background: '#015197', text: '#015197' },
-			{ blackOrWhite: 'white', background: '#c4272f', text: '#c4272f' }
-		]
-	},
-	{
-		name: 'Montenegro',
-		colors: [
-			{ blackOrWhite: 'black', background: '#c4722a', text: '#c4722a' },
-			{ blackOrWhite: 'black', background: '#d3ad3b', text: '#d3ad3b' },
-			{ blackOrWhite: 'white', background: '#c40308', text: '#c40308' }
-		]
-	},
-	{
-		name: 'Mozambique',
-		colors: [
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' },
-			{ blackOrWhite: 'white', background: '#007168', text: '#007168' },
-			{ blackOrWhite: 'black', background: '#fce100', text: '#dfc700' }
-		]
-	},
-	{
-		name: 'Myanmar',
-		colors: [
-			{ blackOrWhite: 'black', background: '#34b233', text: '#34b233' },
-			{ blackOrWhite: 'white', background: '#ea2839', text: '#ea2839' },
-			{ blackOrWhite: 'black', background: '#fecb00', text: '#f1c100' }
-		]
-	},
-	{
-		name: 'Namibia',
-		colors: [
-			{ blackOrWhite: 'white', background: '#d21034', text: '#d21034' },
-			{ blackOrWhite: 'white', background: '#003580', text: '#003580' },
-			{ blackOrWhite: 'white', background: '#009543', text: '#009543' }
-		]
-	},
-	{
-		name: 'Nauru',
-		colors: [
-			{ blackOrWhite: 'white', background: '#334a6c', text: '#334a6c' },
-			{ blackOrWhite: 'black', background: '#ffc61e', text: '#f6be00' },
-			{ blackOrWhite: 'white', background: '#002b7f', text: '#002b7f' }
-		]
-	},
-	{
-		name: 'Nepal',
-		colors: [
-			{ blackOrWhite: 'black', background: '#ffecec', text: '#ffb3b3' },
-			{ blackOrWhite: 'white', background: '#dc143c', text: '#dc143c' },
-			{ blackOrWhite: 'white', background: '#003a96', text: '#003a96' }
-		]
-	},
-	{
-		name: 'Kingdom of the Netherlands',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#ae1c28', text: '#ae1c28' },
-			{ blackOrWhite: 'white', background: '#21468b', text: '#21468b' }
-		]
-	},
-	{
-		name: 'New Zealand',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f7eef7', text: '#dfbcdf' },
-			{ blackOrWhite: 'white', background: '#cc142b', text: '#cc142b' },
-			{ blackOrWhite: 'white', background: '#00247d', text: '#00247d' }
-		]
-	},
-	{
-		name: 'Nicaragua',
-		colors: [
-			{ blackOrWhite: 'black', background: '#abcdec', text: '#a6cbeb' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#0067c6', text: '#0067c6' }
-		]
-	},
-	{
-		name: 'Niger',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'black', background: '#0db02b', text: '#0db02b' },
-			{ blackOrWhite: 'white', background: '#e05206', text: '#e05206' }
-		]
-	},
-	{
-		name: 'Norway',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#002868', text: '#002868' },
-			{ blackOrWhite: 'white', background: '#ef2b2d', text: '#ef2b2d' }
-		]
-	},
-	{
-		name: 'Oman',
-		colors: [
-			{ blackOrWhite: 'white', background: '#008000', text: '#008000' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#db161b', text: '#db161b' }
-		]
-	},
-	{
-		name: 'Pakistan',
-		colors: [
-			{ blackOrWhite: 'black', background: '#82a18f', text: '#82a18f' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#01411c', text: '#01411c' }
-		]
-	},
-	{
-		name: 'Palau',
-		colors: [
-			{ blackOrWhite: 'black', background: '#d4d233', text: '#cecc31' },
-			{ blackOrWhite: 'black', background: '#ffde00', text: '#e3c600' },
-			{ blackOrWhite: 'black', background: '#4aadd6', text: '#4aadd6' }
-		]
-	},
-	{
-		name: 'State of Palestine',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#007a3d', text: '#007a3d' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' }
-		]
-	},
-	{
-		name: 'Panama',
-		colors: [
-			{ blackOrWhite: 'white', background: '#d21034', text: '#d21034' },
-			{ blackOrWhite: 'white', background: '#005293', text: '#005293' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' }
-		]
-	},
-	{
-		name: 'Papua New Guinea',
-		colors: [
-			{ blackOrWhite: 'black', background: '#fcd016', text: '#ecc314' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' }
-		]
-	},
-	{
-		name: 'Paraguay',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#0038a8', text: '#0038a8' },
-			{ blackOrWhite: 'white', background: '#d52b1e', text: '#d52b1e' }
-		]
-	},
-	{
-		name: 'Philippines',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f9f900', text: '#cdcd00' },
-			{ blackOrWhite: 'white', background: '#0038a8', text: '#0038a8' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' }
-		]
-	},
-	{
-		name: 'Portugal',
-		colors: [
-			{ blackOrWhite: 'black', background: '#959e01', text: '#959e01' },
-			{ blackOrWhite: 'white', background: '#006600', text: '#006600' },
-			{ blackOrWhite: 'white', background: '#ff0000', text: '#ff0000' }
-		]
-	},
-	{
-		name: 'Qatar',
-		colors: [
-			{ blackOrWhite: 'white', background: '#b2657d', text: '#b2657d' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#8d1b3d', text: '#8d1b3d' }
-		]
-	},
-	{
-		name: 'Russia',
-		colors: [
-			{ blackOrWhite: 'white', background: '#0039a6', text: '#0039a6' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#d52b1e', text: '#d52b1e' }
-		]
-	},
-	{
-		name: 'Rwanda',
-		colors: [
-			{ blackOrWhite: 'white', background: '#20603d', text: '#20603d' },
-			{ blackOrWhite: 'black', background: '#fad201', text: '#e9c401' },
-			{ blackOrWhite: 'black', background: '#00a1de', text: '#00a1de' }
-		]
-	},
-	{
-		name: 'Saint Kitts and Nevis',
-		colors: [
-			{ blackOrWhite: 'black', background: '#009e49', text: '#009e49' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' }
-		]
-	},
-	{
-		name: 'Saint Lucia',
-		colors: [
-			{ blackOrWhite: 'black', background: '#e7f3f3', text: '#333333' },
-			{ blackOrWhite: 'black', background: '#fcd116', text: '#ebc314' },
-			{ blackOrWhite: 'black', background: '#66ccff', text: '#66ccff' }
-		]
-	},
-	{
-		name: 'Saint Vincent and the Grenadines',
-		colors: [
-			{ blackOrWhite: 'white', background: '#0072c6', text: '#0072c6' },
-			{ blackOrWhite: 'black', background: '#009e60', text: '#009e60' },
-			{ blackOrWhite: 'black', background: '#fcd116', text: '#ebc314' }
-		]
-	},
-	{
-		name: 'Samoa',
-		colors: [
-			{ blackOrWhite: 'black', background: '#edf1f6', text: '#b4c9dc' },
-			{ blackOrWhite: 'white', background: '#002b7f', text: '#002b7f' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' }
-		]
-	},
-	{
-		name: 'San Marino',
-		colors: [
-			{ blackOrWhite: 'white', background: '#86681d', text: '#86681d' },
-			{ blackOrWhite: 'black', background: '#5eb6e4', text: '#5eb6e4' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' }
-		]
-	},
-	{
-		name: 'São Tomé and Príncipe',
-		colors: [
-			{ blackOrWhite: 'white', background: '#d21034', text: '#d21034' },
-			{ blackOrWhite: 'black', background: '#ffce00', text: '#efc100' },
-			{ blackOrWhite: 'black', background: '#12ad2b', text: '#12ad2b' }
-		]
-	},
-	{
-		name: 'Saudi Arabia',
-		colors: [
-			{ blackOrWhite: 'black', background: '#4c9872', text: '#4c9872' },
-			{ blackOrWhite: 'black', background: '#e7f4ed', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#006c35', text: '#006c35' }
-		]
-	},
-	{
-		name: 'Senegal',
-		colors: [
-			{ blackOrWhite: 'black', background: '#fdef42', text: '#d6ca36' },
-			{ blackOrWhite: 'white', background: '#e31b23', text: '#e31b23' },
-			{ blackOrWhite: 'white', background: '#00853f', text: '#00853f' }
-		]
-	},
-	{
-		name: 'Serbia',
-		colors: [
-			{ blackOrWhite: 'black', background: '#cf9e2e', text: '#cf9e2e' },
-			{ blackOrWhite: 'white', background: '#0c4076', text: '#0c4076' },
-			{ blackOrWhite: 'white', background: '#c6363c', text: '#c6363c' }
-		]
-	},
-	{
-		name: 'Seychelles',
-		colors: [
-			{ blackOrWhite: 'black', background: '#fcd856', text: '#e6c440' },
-			{ blackOrWhite: 'white', background: '#003f87', text: '#003f87' },
-			{ blackOrWhite: 'white', background: '#d62828', text: '#d62828' }
-		]
-	},
-	{
-		name: 'Sierra Leone',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#0072c6', text: '#0072c6' },
-			{ blackOrWhite: 'black', background: '#1eb53a', text: '#1eb53a' }
-		]
-	},
-	{
-		name: 'Singapore',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f58c94', text: '#f58c94' },
-			{ blackOrWhite: 'white', background: '#ed2939', text: '#ed2939' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' }
-		]
-	},
-	{
-		name: 'Slovakia',
-		colors: [
-			{ blackOrWhite: 'white', background: '#0b4ea2', text: '#0b4ea2' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#ee1c25', text: '#ee1c25' }
-		]
-	},
-	{
-		name: 'Slovenia',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#005da4', text: '#005da4' },
-			{ blackOrWhite: 'white', background: '#ed1c24', text: '#ed1c24' }
-		]
-	},
-	{
-		name: 'Solomon Islands',
-		colors: [
-			{ blackOrWhite: 'black', background: '#fcd116', text: '#ebc314' },
-			{ blackOrWhite: 'white', background: '#0051ba', text: '#0051ba' },
-			{ blackOrWhite: 'white', background: '#215b33', text: '#215b33' }
-		]
-	},
-	{
-		name: 'South Africa',
-		colors: [
-			{ blackOrWhite: 'white', background: '#002395', text: '#002395' },
-			{ blackOrWhite: 'white', background: '#de3831', text: '#de3831' },
-			{ blackOrWhite: 'white', background: '#007a4d', text: '#007a4d' }
-		]
-	},
-	{
-		name: 'South Sudan',
-		colors: [
-			{ blackOrWhite: 'white', background: '#0f47af', text: '#0f47af' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' },
-			{ blackOrWhite: 'white', background: '#078930', text: '#078930' }
-		]
-	},
-	{
-		name: 'Spain',
-		colors: [
-			{ blackOrWhite: 'white', background: '#975c11', text: '#975c11' },
-			{ blackOrWhite: 'black', background: '#ffc400', text: '#f7be00' },
-			{ blackOrWhite: 'white', background: '#c60b1e', text: '#c60b1e' }
-		]
-	},
-	{
-		name: 'Sri Lanka',
-		colors: [
-			{ blackOrWhite: 'white', background: '#005641', text: '#005641' },
-			{ blackOrWhite: 'white', background: '#8d2029', text: '#8d2029' },
-			{ blackOrWhite: 'black', background: '#feb700', text: '#feb700' }
-		]
-	},
-	{
-		name: 'Sudan',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#d21034', text: '#d21034' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' }
-		]
-	},
-	{
-		name: 'Suriname',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#b40a2d', text: '#b40a2d' },
-			{ blackOrWhite: 'white', background: '#377e3f', text: '#377e3f' }
-		]
-	},
-	{
-		name: 'Swaziland',
-		colors: [
-			{ blackOrWhite: 'black', background: '#fed800', text: '#e7c400' },
-			{ blackOrWhite: 'white', background: '#b10c0c', text: '#b10c0c' },
-			{ blackOrWhite: 'white', background: '#3e5eb9', text: '#3e5eb9' }
-		]
-	},
-	{
-		name: 'Switzerland',
-		colors: [
-			{ blackOrWhite: 'black', background: '#ff6060', text: '#ff6060' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#ff0000', text: '#ff0000' }
-		]
-	},
-	{
-		name: 'Syria',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' }
-		]
-	},
-	{
-		name: 'Tajikistan',
-		colors: [
-			{ blackOrWhite: 'white', background: '#006600', text: '#006600' },
-			{ blackOrWhite: 'white', background: '#cc0000', text: '#cc0000' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' }
-		]
-	},
-	{
-		name: 'Tanzania',
-		colors: [
-			{ blackOrWhite: 'black', background: '#00a3dd', text: '#00a3dd' },
-			{ blackOrWhite: 'black', background: '#1eb53a', text: '#1eb53a' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' }
-		]
-	},
-	{
-		name: 'Thailand',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#241d4f', text: '#241d4f' },
-			{ blackOrWhite: 'white', background: '#ed1c24', text: '#ed1c24' }
-		]
-	},
-	{
-		name: 'Togo',
-		colors: [
-			{ blackOrWhite: 'white', background: '#d21034', text: '#d21034' },
-			{ blackOrWhite: 'black', background: '#ffce00', text: '#efc100' },
-			{ blackOrWhite: 'white', background: '#006a4e', text: '#006a4e' }
-		]
-	},
-	{
-		name: 'Tonga',
-		colors: [
-			{ blackOrWhite: 'white', background: '#d65555', text: '#d65555' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#c10000', text: '#c10000' }
-		]
-	},
-	{
-		name: 'Trinidad and Tobago',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f7eef7', text: '#dfbcdf' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' }
-		]
-	},
-	{
-		name: 'Tunisia',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f16c77', text: '#f16c77' },
-			{ blackOrWhite: 'black', background: '#ffecec', text: '#ffb3b3' },
-			{ blackOrWhite: 'white', background: '#e70013', text: '#e70013' }
-		]
-	},
-	{
-		name: 'Turkey',
-		colors: [
-			{ blackOrWhite: 'black', background: '#ef7279', text: '#ef7279' },
-			{ blackOrWhite: 'black', background: '#ffecec', text: '#ffb3b3' },
-			{ blackOrWhite: 'white', background: '#e30a17', text: '#e30a17' }
-		]
-	},
-	{
-		name: 'Turkmenistan',
-		colors: [
-			{ blackOrWhite: 'white', background: '#b47134', text: '#b47134' },
-			{ blackOrWhite: 'white', background: '#c93745', text: '#c93745' },
-			{ blackOrWhite: 'black', background: '#28ae66', text: '#28ae66' }
-		]
-	},
-	{
-		name: 'Tuvalu',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#cf142b', text: '#cf142b' },
-			{ blackOrWhite: 'black', background: '#5b97b1', text: '#5b97b1' }
-		]
-	},
-	{
-		name: 'Uganda',
-		colors: [
-			{ blackOrWhite: 'white', background: '#d90000', text: '#d90000' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' },
-			{ blackOrWhite: 'black', background: '#fcdc04', text: '#e3c603' }
-		]
-	},
-	{
-		name: 'United Arab Emirates',
-		colors: [
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' },
-			{ blackOrWhite: 'white', background: '#00732f', text: '#00732f' },
-			{ blackOrWhite: 'white', background: '#ff0000', text: '#ff0000' }
-		]
-	},
-	{
-		name: 'United Kingdom',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f3c4ca', text: '#f1b8bf' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#cf142b', text: '#cf142b' }
-		]
-	},
-	{
-		name: 'United States',
-		colors: [
-			{ blackOrWhite: 'white', background: '#3c3b6e', text: '#3c3b6e' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#b22234', text: '#b22234' }
-		]
-	},
-	{
-		name: 'Uruguay',
-		colors: [
-			{ blackOrWhite: 'black', background: '#c6d3ec', text: '#b6c7e7' },
-			{ blackOrWhite: 'black', background: '#9e830e', text: '#9e830e' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' }
-		]
-	},
-	{
-		name: 'Uzbekistan',
-		colors: [
-			{ blackOrWhite: 'black', background: '#0099b5', text: '#0099b5' },
-			{ blackOrWhite: 'black', background: '#1eb53a', text: '#1eb53a' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' }
-		]
-	},
-	{
-		name: 'Vanuatu',
-		colors: [
-			{ blackOrWhite: 'white', background: '#010100', text: '#010100' },
-			{ blackOrWhite: 'white', background: '#d21034', text: '#d21034' },
-			{ blackOrWhite: 'white', background: '#009543', text: '#009543' }
-		]
-	},
-	{
-		name: 'Vatican City',
-		colors: [
-			{ blackOrWhite: 'black', background: '#d1d0ce', text: '#333333' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'black', background: '#ffe000', text: '#e2c600' }
-		]
-	},
-	{
-		name: 'Venezuela',
-		colors: [
-			{ blackOrWhite: 'white', background: '#00247d', text: '#00247d' },
-			{ blackOrWhite: 'black', background: '#ffcc00', text: '#f1c100' },
-			{ blackOrWhite: 'white', background: '#cf142b', text: '#cf142b' }
-		]
-	},
-	{
-		name: 'Yemen',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' },
-			{ blackOrWhite: 'white', background: '#ce1126', text: '#ce1126' }
-		]
-	},
-	{
-		name: 'Zambia',
-		colors: [
-			{ blackOrWhite: 'white', background: '#de2010', text: '#de2010' },
-			{ blackOrWhite: 'black', background: '#ef7d00', text: '#ef7d00' },
-			{ blackOrWhite: 'white', background: '#198a00', text: '#198a00' }
-		]
-	},
-	{
-		name: 'Zimbabwe',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#de2010', text: '#de2010' },
-			{ blackOrWhite: 'white', background: '#319208', text: '#319208' }
-		]
-	},
-	{
-		name: 'Abkhazia',
-		colors: [
-			{ blackOrWhite: 'white', background: '#c8312a', text: '#c8312a' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'black', background: '#00993e', text: '#00993e' }
-		]
-	},
-	{
-		name: 'Cook Islands',
-		colors: [
-			{ blackOrWhite: 'white', background: '#cf142b', text: '#cf142b' },
-			{ blackOrWhite: 'black', background: '#f0f0f8', text: '#c4c4e2' },
-			{ blackOrWhite: 'white', background: '#00247d', text: '#00247d' }
-		]
-	},
-	{
-		name: 'Kosovo',
-		colors: [
-			{ blackOrWhite: 'black', background: '#ecf1fa', text: '#b1c8ed' },
-			{ blackOrWhite: 'black', background: '#d0a650', text: '#d0a650' },
-			{ blackOrWhite: 'white', background: '#244aa5', text: '#244aa5' }
-		]
-	},
-	{
-		name: 'Nagorno-Karabakh Republic',
-		colors: [
-			{ blackOrWhite: 'white', background: '#0033a0', text: '#0033a0' },
-			{ blackOrWhite: 'white', background: '#d90012', text: '#d90012' },
-			{ blackOrWhite: 'black', background: '#f2a800', text: '#f2a800' }
-		]
-	},
-	{
-		name: 'Niue',
-		colors: [
-			{ blackOrWhite: 'white', background: '#cf142b', text: '#cf142b' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'black', background: '#fcd116', text: '#ebc314' }
-		]
-	},
-	{
-		name: 'Northern Cyprus',
-		colors: [
-			{ blackOrWhite: 'black', background: '#ea4b55', text: '#ea4b55' },
-			{ blackOrWhite: 'white', background: '#e30a17', text: '#e30a17' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' }
-		]
-	},
-	{
-		name: 'Sahrawi Arab Democratic Republic',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#007a3d', text: '#007a3d' },
-			{ blackOrWhite: 'white', background: '#000000', text: '#000000' }
-		]
-	},
-	{
-		name: 'Somaliland',
-		colors: [
-			{ blackOrWhite: 'black', background: '#9b9f9c', text: '#9b9f9c' },
-			{ blackOrWhite: 'white', background: '#006d21', text: '#006d21' },
-			{ blackOrWhite: 'white', background: '#020202', text: '#020202' }
-		]
-	},
-	{
-		name: 'South Ossetia',
-		colors: [
-			{ blackOrWhite: 'white', background: '#ff0000', text: '#ff0000' },
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'black', background: '#ffdf00', text: '#e3c600' }
-		]
-	},
-	{
-		name: 'Taiwan',
-		colors: [
-			{ blackOrWhite: 'black', background: '#f1f1f1', text: '#333333' },
-			{ blackOrWhite: 'white', background: '#000095', text: '#000095' },
-			{ blackOrWhite: 'white', background: '#fe0000', text: '#fe0000' }
-		]
-	},
-	{
-		name: 'Transnistria',
-		colors: [
-			{ blackOrWhite: 'white', background: '#6f4d1a', text: '#6f4d1a' },
-			{ blackOrWhite: 'black', background: '#009933', text: '#009933' },
-			{ blackOrWhite: 'white', background: '#de0000', text: '#de0000' }
-		]
-	}
+  {
+    name: "Afghanistan",
+    colors: [
+      { blackOrWhite: "white", background: "#bf0000", text: "#bf0000" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" },
+      { blackOrWhite: "white", background: "#009900", text: "#009900" }
+    ]
+  },
+  {
+    name: "Albania",
+    colors: [
+      { blackOrWhite: "white", background: "#6f0f10", text: "#6f0f10" },
+      { blackOrWhite: "white", background: "#020000", text: "#020000" },
+      { blackOrWhite: "white", background: "#e41e20", text: "#e41e20" }
+    ]
+  },
+  {
+    name: "Algeria",
+    colors: [
+      { blackOrWhite: "white", background: "#d21034", text: "#d21034" },
+      { blackOrWhite: "white", background: "#006233", text: "#006233" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" }
+    ]
+  },
+  {
+    name: "Andorra",
+    colors: [
+      { blackOrWhite: "black", background: "#fdde00", text: "#e2c600" },
+      { blackOrWhite: "white", background: "#0018a8", text: "#0018a8" },
+      { blackOrWhite: "white", background: "#d0103a", text: "#d0103a" }
+    ]
+  },
+  {
+    name: "Angola",
+    colors: [
+      { blackOrWhite: "black", background: "#f7d416", text: "#e6c514" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" }
+    ]
+  },
+  {
+    name: "Antigua and Barbuda",
+    colors: [
+      { blackOrWhite: "white", background: "#0072c6", text: "#0072c6" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" }
+    ]
+  },
+  {
+    name: "Argentina",
+    colors: [
+      { blackOrWhite: "black", background: "#d1e3f4", text: "#a5cbeb" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "black", background: "#74acdf", text: "#74acdf" }
+    ]
+  },
+  {
+    name: "Armenia",
+    colors: [
+      { blackOrWhite: "white", background: "#0033a0", text: "#0033a0" },
+      { blackOrWhite: "black", background: "#f2a800", text: "#f2a800" },
+      { blackOrWhite: "white", background: "#d90012", text: "#d90012" }
+    ]
+  },
+  {
+    name: "Australia",
+    colors: [
+      { blackOrWhite: "white", background: "#ff0101", text: "#ff0101" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#00008b", text: "#00008b" }
+    ]
+  },
+  {
+    name: "Azerbaijan",
+    colors: [
+      { blackOrWhite: "white", background: "#ed2939", text: "#ed2939" },
+      { blackOrWhite: "black", background: "#00b9e4", text: "#00b9e4" },
+      { blackOrWhite: "black", background: "#3f9c35", text: "#3f9c35" }
+    ]
+  },
+  {
+    name: "the Bahamas",
+    colors: [
+      { blackOrWhite: "black", background: "#fae042", text: "#dec73a" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" },
+      { blackOrWhite: "black", background: "#00abc9", text: "#00abc9" }
+    ]
+  },
+  {
+    name: "Bahrain",
+    colors: [
+      { blackOrWhite: "black", background: "#e78893", text: "#e78893" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" }
+    ]
+  },
+  {
+    name: "Bangladesh",
+    colors: [
+      { blackOrWhite: "white", background: "#6c4e48", text: "#6c4e48" },
+      { blackOrWhite: "white", background: "#f42a41", text: "#f42a41" },
+      { blackOrWhite: "white", background: "#006a4e", text: "#006a4e" }
+    ]
+  },
+  {
+    name: "Barbados",
+    colors: [
+      { blackOrWhite: "white", background: "#010100", text: "#010100" },
+      { blackOrWhite: "black", background: "#ffc726", text: "#f6bf00" },
+      { blackOrWhite: "white", background: "#00267f", text: "#00267f" }
+    ]
+  },
+  {
+    name: "Belarus",
+    colors: [
+      { blackOrWhite: "black", background: "#fceded", text: "#f3b8b8" },
+      { blackOrWhite: "black", background: "#4aa657", text: "#4aa657" },
+      { blackOrWhite: "white", background: "#c8313e", text: "#c8313e" }
+    ]
+  },
+  {
+    name: "Belize",
+    colors: [
+      { blackOrWhite: "black", background: "#d5dbd6", text: "#333333" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" },
+      { blackOrWhite: "white", background: "#003f87", text: "#003f87" }
+    ]
+  },
+  {
+    name: "Bhutan",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "black", background: "#ff4e12", text: "#ff4e12" },
+      { blackOrWhite: "black", background: "#ffd520", text: "#ebc300" }
+    ]
+  },
+  {
+    name: "Bolivia",
+    colors: [
+      { blackOrWhite: "black", background: "#ffe000", text: "#e2c600" },
+      { blackOrWhite: "white", background: "#007934", text: "#007934" },
+      { blackOrWhite: "white", background: "#d52b1e", text: "#d52b1e" }
+    ]
+  },
+  {
+    name: "Bosnia and Herzegovina",
+    colors: [
+      { blackOrWhite: "black", background: "#f0f0f8", text: "#c4c4e2" },
+      { blackOrWhite: "black", background: "#fecb00", text: "#f1c100" },
+      { blackOrWhite: "white", background: "#002395", text: "#002395" }
+    ]
+  },
+  {
+    name: "Botswana",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" },
+      { blackOrWhite: "black", background: "#75aadb", text: "#75aadb" }
+    ]
+  },
+  {
+    name: "Brazil",
+    colors: [
+      { blackOrWhite: "white", background: "#012876", text: "#012876" },
+      { blackOrWhite: "black", background: "#fddf00", text: "#e1c600" },
+      { blackOrWhite: "black", background: "#009b3a", text: "#009b3a" }
+    ]
+  },
+  {
+    name: "Brunei",
+    colors: [
+      { blackOrWhite: "white", background: "#010000", text: "#010000" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "black", background: "#f7e017", text: "#ddc813" }
+    ]
+  },
+  {
+    name: "Bulgaria",
+    colors: [
+      { blackOrWhite: "black", background: "#00966e", text: "#00966e" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#d62612", text: "#d62612" }
+    ]
+  },
+  {
+    name: "Burkina Faso",
+    colors: [
+      { blackOrWhite: "black", background: "#fcd116", text: "#ebc314" },
+      { blackOrWhite: "white", background: "#ef2b2d", text: "#ef2b2d" },
+      { blackOrWhite: "black", background: "#009e49", text: "#009e49" }
+    ]
+  },
+  {
+    name: "Burundi",
+    colors: [
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "black", background: "#1eb53a", text: "#1eb53a" }
+    ]
+  },
+  {
+    name: "Cambodia",
+    colors: [
+      { blackOrWhite: "black", background: "#a49fa0", text: "#a49fa0" },
+      { blackOrWhite: "white", background: "#e00025", text: "#e00025" },
+      { blackOrWhite: "white", background: "#032ea1", text: "#032ea1" }
+    ]
+  },
+  {
+    name: "Cameroon",
+    colors: [
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" },
+      { blackOrWhite: "white", background: "#007a5e", text: "#007a5e" },
+      { blackOrWhite: "black", background: "#fcd116", text: "#ebc314" }
+    ]
+  },
+  {
+    name: "Canada",
+    colors: [
+      { blackOrWhite: "black", background: "#ffd0d0", text: "#ffb3b3" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#ff0000", text: "#ff0000" }
+    ]
+  },
+  {
+    name: "Cape Verde",
+    colors: [
+      { blackOrWhite: "white", background: "#cf2027", text: "#cf2027" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#003893", text: "#003893" }
+    ]
+  },
+  {
+    name: "Central African Republic",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#289728", text: "#289728" },
+      { blackOrWhite: "black", background: "#ffce00", text: "#efc100" }
+    ]
+  },
+  {
+    name: "Chile",
+    colors: [
+      { blackOrWhite: "white", background: "#0039a6", text: "#0039a6" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#d52b1e", text: "#d52b1e" }
+    ]
+  },
+  {
+    name: "Comoros",
+    colors: [
+      { blackOrWhite: "white", background: "#3d8e33", text: "#3d8e33" },
+      { blackOrWhite: "black", background: "#ffc61e", text: "#f6be00" },
+      { blackOrWhite: "white", background: "#3a75c4", text: "#3a75c4" }
+    ]
+  },
+  {
+    name: "Democratic Republic of the Congo",
+    colors: [
+      { blackOrWhite: "black", background: "#f7d518", text: "#e5c515" },
+      { blackOrWhite: "white", background: "#ce1021", text: "#ce1021" },
+      { blackOrWhite: "white", background: "#007fff", text: "#007fff" }
+    ]
+  },
+  {
+    name: "Congo",
+    colors: [
+      { blackOrWhite: "black", background: "#fbde4a", text: "#e0c641" },
+      { blackOrWhite: "white", background: "#009543", text: "#009543" },
+      { blackOrWhite: "white", background: "#dc241f", text: "#dc241f" }
+    ]
+  },
+  {
+    name: "Costa Rica",
+    colors: [
+      { blackOrWhite: "white", background: "#002b7f", text: "#002b7f" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" }
+    ]
+  },
+  {
+    name: "Croatia",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#171796", text: "#171796" },
+      { blackOrWhite: "white", background: "#ff0000", text: "#ff0000" }
+    ]
+  },
+  {
+    name: "Cuba",
+    colors: [
+      { blackOrWhite: "white", background: "#cf142b", text: "#cf142b" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#002a8f", text: "#002a8f" }
+    ]
+  },
+  {
+    name: "Cyprus",
+    colors: [
+      { blackOrWhite: "black", background: "#f0e6d6", text: "#d8c4a0" },
+      { blackOrWhite: "black", background: "#d47600", text: "#d47600" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" }
+    ]
+  },
+  {
+    name: "Czech Republic",
+    colors: [
+      { blackOrWhite: "white", background: "#11457e", text: "#11457e" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#d7141a", text: "#d7141a" }
+    ]
+  },
+  {
+    name: "Djibouti",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "black", background: "#12ad2b", text: "#12ad2b" },
+      { blackOrWhite: "black", background: "#6ab2e7", text: "#6ab2e7" }
+    ]
+  },
+  {
+    name: "Dominica",
+    colors: [
+      { blackOrWhite: "black", background: "#fcd116", text: "#ebc314" },
+      { blackOrWhite: "white", background: "#d31c30", text: "#d31c30" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" }
+    ]
+  },
+  {
+    name: "Dominican Republic",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#002d62", text: "#002d62" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" }
+    ]
+  },
+  {
+    name: "Timor-Leste",
+    colors: [
+      { blackOrWhite: "black", background: "#ffc726", text: "#f6bf00" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" },
+      { blackOrWhite: "white", background: "#dc241f", text: "#dc241f" }
+    ]
+  },
+  {
+    name: "Ecuador",
+    colors: [
+      { blackOrWhite: "white", background: "#034ea2", text: "#034ea2" },
+      { blackOrWhite: "white", background: "#ed1c24", text: "#ed1c24" },
+      { blackOrWhite: "black", background: "#ffdd00", text: "#e4c600" }
+    ]
+  },
+  {
+    name: "Egypt",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" }
+    ]
+  },
+  {
+    name: "El Salvador",
+    colors: [
+      { blackOrWhite: "black", background: "#b0c2e5", text: "#b0c2e5" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#0f47af", text: "#0f47af" }
+    ]
+  },
+  {
+    name: "Equatorial Guinea",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "black", background: "#3e9a00", text: "#3e9a00" },
+      { blackOrWhite: "white", background: "#e32118", text: "#e32118" }
+    ]
+  },
+  {
+    name: "Eritrea",
+    colors: [
+      { blackOrWhite: "black", background: "#12ad2b", text: "#12ad2b" },
+      { blackOrWhite: "black", background: "#4189dd", text: "#4189dd" },
+      { blackOrWhite: "white", background: "#ea0437", text: "#ea0437" }
+    ]
+  },
+  {
+    name: "Estonia",
+    colors: [
+      { blackOrWhite: "white", background: "#000000", text: "#000000" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "black", background: "#4891d9", text: "#4891d9" }
+    ]
+  },
+  {
+    name: "Ethiopia",
+    colors: [
+      { blackOrWhite: "black", background: "#fbdd09", text: "#e2c607" },
+      { blackOrWhite: "white", background: "#da121a", text: "#da121a" },
+      { blackOrWhite: "white", background: "#078930", text: "#078930" }
+    ]
+  },
+  {
+    name: "Fiji",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#cf1129", text: "#cf1129" },
+      { blackOrWhite: "black", background: "#68bfe5", text: "#68bfe5" }
+    ]
+  },
+  {
+    name: "Finland",
+    colors: [
+      { blackOrWhite: "white", background: "#5c7eae", text: "#5c7eae" },
+      { blackOrWhite: "white", background: "#003580", text: "#003580" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" }
+    ]
+  },
+  {
+    name: "Gabon",
+    colors: [
+      { blackOrWhite: "black", background: "#fcd116", text: "#ebc314" },
+      { blackOrWhite: "black", background: "#009e60", text: "#009e60" },
+      { blackOrWhite: "white", background: "#3a75c4", text: "#3a75c4" }
+    ]
+  },
+  {
+    name: "the Gambia",
+    colors: [
+      { blackOrWhite: "white", background: "#0c1c8c", text: "#0c1c8c" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" },
+      { blackOrWhite: "white", background: "#3a7728", text: "#3a7728" }
+    ]
+  },
+  {
+    name: "Georgia",
+    colors: [
+      { blackOrWhite: "black", background: "#ff8e8e", text: "#ff8e8e" },
+      { blackOrWhite: "white", background: "#ff0000", text: "#ff0000" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" }
+    ]
+  },
+  {
+    name: "Germany",
+    colors: [
+      { blackOrWhite: "white", background: "#dd0000", text: "#dd0000" },
+      { blackOrWhite: "black", background: "#ffce00", text: "#efc100" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" }
+    ]
+  },
+  {
+    name: "Ghana",
+    colors: [
+      { blackOrWhite: "black", background: "#fcd116", text: "#ebc314" },
+      { blackOrWhite: "white", background: "#006b3f", text: "#006b3f" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" }
+    ]
+  },
+  {
+    name: "Greece",
+    colors: [
+      { blackOrWhite: "black", background: "#79a6d3", text: "#79a6d3" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#0d5eaf", text: "#0d5eaf" }
+    ]
+  },
+  {
+    name: "Grenada",
+    colors: [
+      { blackOrWhite: "white", background: "#007a5e", text: "#007a5e" },
+      { blackOrWhite: "black", background: "#fcd116", text: "#ebc314" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" }
+    ]
+  },
+  {
+    name: "Guatemala",
+    colors: [
+      { blackOrWhite: "black", background: "#c3ddf0", text: "#a1cce9" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "black", background: "#4997d0", text: "#4997d0" }
+    ]
+  },
+  {
+    name: "Guinea-Bissau",
+    colors: [
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" },
+      { blackOrWhite: "black", background: "#009e49", text: "#009e49" },
+      { blackOrWhite: "black", background: "#fcd116", text: "#ebc314" }
+    ]
+  },
+  {
+    name: "Guyana",
+    colors: [
+      { blackOrWhite: "black", background: "#fcd116", text: "#ebc314" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" },
+      { blackOrWhite: "black", background: "#009e49", text: "#009e49" }
+    ]
+  },
+  {
+    name: "Haiti",
+    colors: [
+      { blackOrWhite: "white", background: "#1d6d1f", text: "#1d6d1f" },
+      { blackOrWhite: "white", background: "#00209f", text: "#00209f" },
+      { blackOrWhite: "white", background: "#d21034", text: "#d21034" }
+    ]
+  },
+  {
+    name: "Honduras",
+    colors: [
+      { blackOrWhite: "black", background: "#aad0ef", text: "#a1ccee" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#0073cf", text: "#0073cf" }
+    ]
+  },
+  {
+    name: "Hungary",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#436f4d", text: "#436f4d" },
+      { blackOrWhite: "white", background: "#cd2a3e", text: "#cd2a3e" }
+    ]
+  },
+  {
+    name: "Iceland",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#d72828", text: "#d72828" },
+      { blackOrWhite: "white", background: "#003897", text: "#003897" }
+    ]
+  },
+  {
+    name: "India",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "black", background: "#ff9933", text: "#ff9933" },
+      { blackOrWhite: "white", background: "#128807", text: "#128807" }
+    ]
+  },
+  {
+    name: "Iran",
+    colors: [
+      { blackOrWhite: "black", background: "#239f40", text: "#239f40" },
+      { blackOrWhite: "white", background: "#da0101", text: "#da0101" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" }
+    ]
+  },
+  {
+    name: "Iraq",
+    colors: [
+      { blackOrWhite: "white", background: "#14844c", text: "#14844c" },
+      { blackOrWhite: "black", background: "#dcede5", text: "#333333" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" }
+    ]
+  },
+  {
+    name: "Ireland",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "black", background: "#169b62", text: "#169b62" },
+      { blackOrWhite: "black", background: "#ff883e", text: "#ff883e" }
+    ]
+  },
+  {
+    name: "Israel",
+    colors: [
+      { blackOrWhite: "black", background: "#5f82d2", text: "#5f82d2" },
+      { blackOrWhite: "white", background: "#0038b8", text: "#0038b8" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" }
+    ]
+  },
+  {
+    name: "Jamaica",
+    colors: [
+      { blackOrWhite: "black", background: "#fed100", text: "#ecc200" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" },
+      { blackOrWhite: "black", background: "#009b3a", text: "#009b3a" }
+    ]
+  },
+  {
+    name: "Japan",
+    colors: [
+      { blackOrWhite: "white", background: "#d14f6e", text: "#d14f6e" },
+      { blackOrWhite: "white", background: "#bc002d", text: "#bc002d" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" }
+    ]
+  },
+  {
+    name: "Jordan",
+    colors: [
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" },
+      { blackOrWhite: "white", background: "#007a3d", text: "#007a3d" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" }
+    ]
+  },
+  {
+    name: "Kazakhstan",
+    colors: [
+      { blackOrWhite: "black", background: "#97bc59", text: "#97bc59" },
+      { blackOrWhite: "black", background: "#fac50f", text: "#f3c00e" },
+      { blackOrWhite: "black", background: "#00afca", text: "#00afca" }
+    ]
+  },
+  {
+    name: "Kenya",
+    colors: [
+      { blackOrWhite: "white", background: "#006600", text: "#006600" },
+      { blackOrWhite: "white", background: "#bb0000", text: "#bb0000" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" }
+    ]
+  },
+  {
+    name: "Kiribati",
+    colors: [
+      { blackOrWhite: "black", background: "#facf15", text: "#ebc313" },
+      { blackOrWhite: "black", background: "#ffebff", text: "#ffa9ff" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" }
+    ]
+  },
+  {
+    name: "North Korea",
+    colors: [
+      { blackOrWhite: "black", background: "#ffecec", text: "#ffb3b3" },
+      { blackOrWhite: "white", background: "#024fa2", text: "#024fa2" },
+      { blackOrWhite: "white", background: "#ed1c27", text: "#ed1c27" }
+    ]
+  },
+  {
+    name: "South Korea",
+    colors: [
+      { blackOrWhite: "white", background: "#c60c30", text: "#c60c30" },
+      { blackOrWhite: "white", background: "#013478", text: "#013478" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" }
+    ]
+  },
+  {
+    name: "Kuwait",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#007a3d", text: "#007a3d" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" }
+    ]
+  },
+  {
+    name: "Kyrgyzstan",
+    colors: [
+      { blackOrWhite: "black", background: "#f58e14", text: "#f58e14" },
+      { blackOrWhite: "black", background: "#ffed00", text: "#d9c900" },
+      { blackOrWhite: "white", background: "#e8112d", text: "#e8112d" }
+    ]
+  },
+  {
+    name: "Laos",
+    colors: [
+      { blackOrWhite: "black", background: "#adffff", text: "#00dddd" },
+      { blackOrWhite: "white", background: "#002868", text: "#002868" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" }
+    ]
+  },
+  {
+    name: "Lebanon",
+    colors: [
+      { blackOrWhite: "black", background: "#01a652", text: "#01a652" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#ed1c24", text: "#ed1c24" }
+    ]
+  },
+  {
+    name: "Lesotho",
+    colors: [
+      { blackOrWhite: "white", background: "#00209f", text: "#00209f" },
+      { blackOrWhite: "white", background: "#009543", text: "#009543" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" }
+    ]
+  },
+  {
+    name: "Liberia",
+    colors: [
+      { blackOrWhite: "white", background: "#002868", text: "#002868" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#bf0a30", text: "#bf0a30" }
+    ]
+  },
+  {
+    name: "Libya",
+    colors: [
+      { blackOrWhite: "white", background: "#e70013", text: "#e70013" },
+      { blackOrWhite: "black", background: "#239e46", text: "#239e46" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" }
+    ]
+  },
+  {
+    name: "Liechtenstein",
+    colors: [
+      { blackOrWhite: "black", background: "#bea12e", text: "#bea12e" },
+      { blackOrWhite: "white", background: "#002b7f", text: "#002b7f" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" }
+    ]
+  },
+  {
+    name: "Lithuania",
+    colors: [
+      { blackOrWhite: "white", background: "#006a44", text: "#006a44" },
+      { blackOrWhite: "black", background: "#fdb913", text: "#fdb913" },
+      { blackOrWhite: "white", background: "#c1272d", text: "#c1272d" }
+    ]
+  },
+  {
+    name: "Luxembourg",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "black", background: "#00a1de", text: "#00a1de" },
+      { blackOrWhite: "white", background: "#ed2939", text: "#ed2939" }
+    ]
+  },
+  {
+    name: "Macedonia",
+    colors: [
+      { blackOrWhite: "white", background: "#dc3400", text: "#dc3400" },
+      { blackOrWhite: "black", background: "#ffe600", text: "#dec800" },
+      { blackOrWhite: "white", background: "#d20000", text: "#d20000" }
+    ]
+  },
+  {
+    name: "Malawi",
+    colors: [
+      { blackOrWhite: "white", background: "#000000", text: "#000000" },
+      { blackOrWhite: "black", background: "#339e35", text: "#339e35" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" }
+    ]
+  },
+  {
+    name: "Malaysia",
+    colors: [
+      { blackOrWhite: "white", background: "#010066", text: "#010066" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#cc0001", text: "#cc0001" }
+    ]
+  },
+  {
+    name: "Maldives",
+    colors: [
+      { blackOrWhite: "black", background: "#c9e4d5", text: "#333333" },
+      { blackOrWhite: "white", background: "#007e3a", text: "#007e3a" },
+      { blackOrWhite: "white", background: "#d21034", text: "#d21034" }
+    ]
+  },
+  {
+    name: "Malta",
+    colors: [
+      { blackOrWhite: "black", background: "#a9a29c", text: "#a9a29c" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#cf142b", text: "#cf142b" }
+    ]
+  },
+  {
+    name: "Marshall Islands",
+    colors: [
+      { blackOrWhite: "black", background: "#dd7500", text: "#dd7500" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#003893", text: "#003893" }
+    ]
+  },
+  {
+    name: "Mauritania",
+    colors: [
+      { blackOrWhite: "white", background: "#477d25", text: "#477d25" },
+      { blackOrWhite: "black", background: "#ffc400", text: "#f7be00" },
+      { blackOrWhite: "white", background: "#006233", text: "#006233" }
+    ]
+  },
+  {
+    name: "Mauritius",
+    colors: [
+      { blackOrWhite: "black", background: "#00a551", text: "#00a551" },
+      { blackOrWhite: "white", background: "#ea2839", text: "#ea2839" },
+      { blackOrWhite: "white", background: "#1a206d", text: "#1a206d" }
+    ]
+  },
+  {
+    name: "Mexico",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#006847", text: "#006847" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" }
+    ]
+  },
+  {
+    name: "Moldova",
+    colors: [
+      { blackOrWhite: "black", background: "#ffd200", text: "#ecc200" },
+      { blackOrWhite: "white", background: "#0046ae", text: "#0046ae" },
+      { blackOrWhite: "white", background: "#cc092f", text: "#cc092f" }
+    ]
+  },
+  {
+    name: "Mongolia",
+    colors: [
+      { blackOrWhite: "black", background: "#f9cf02", text: "#ebc302" },
+      { blackOrWhite: "white", background: "#015197", text: "#015197" },
+      { blackOrWhite: "white", background: "#c4272f", text: "#c4272f" }
+    ]
+  },
+  {
+    name: "Montenegro",
+    colors: [
+      { blackOrWhite: "black", background: "#c4722a", text: "#c4722a" },
+      { blackOrWhite: "black", background: "#d3ad3b", text: "#d3ad3b" },
+      { blackOrWhite: "white", background: "#c40308", text: "#c40308" }
+    ]
+  },
+  {
+    name: "Mozambique",
+    colors: [
+      { blackOrWhite: "white", background: "#000000", text: "#000000" },
+      { blackOrWhite: "white", background: "#007168", text: "#007168" },
+      { blackOrWhite: "black", background: "#fce100", text: "#dfc700" }
+    ]
+  },
+  {
+    name: "Myanmar",
+    colors: [
+      { blackOrWhite: "black", background: "#34b233", text: "#34b233" },
+      { blackOrWhite: "white", background: "#ea2839", text: "#ea2839" },
+      { blackOrWhite: "black", background: "#fecb00", text: "#f1c100" }
+    ]
+  },
+  {
+    name: "Namibia",
+    colors: [
+      { blackOrWhite: "white", background: "#d21034", text: "#d21034" },
+      { blackOrWhite: "white", background: "#003580", text: "#003580" },
+      { blackOrWhite: "white", background: "#009543", text: "#009543" }
+    ]
+  },
+  {
+    name: "Nauru",
+    colors: [
+      { blackOrWhite: "white", background: "#334a6c", text: "#334a6c" },
+      { blackOrWhite: "black", background: "#ffc61e", text: "#f6be00" },
+      { blackOrWhite: "white", background: "#002b7f", text: "#002b7f" }
+    ]
+  },
+  {
+    name: "Nepal",
+    colors: [
+      { blackOrWhite: "black", background: "#ffecec", text: "#ffb3b3" },
+      { blackOrWhite: "white", background: "#dc143c", text: "#dc143c" },
+      { blackOrWhite: "white", background: "#003a96", text: "#003a96" }
+    ]
+  },
+  {
+    name: "Kingdom of the Netherlands",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#ae1c28", text: "#ae1c28" },
+      { blackOrWhite: "white", background: "#21468b", text: "#21468b" }
+    ]
+  },
+  {
+    name: "New Zealand",
+    colors: [
+      { blackOrWhite: "black", background: "#f7eef7", text: "#dfbcdf" },
+      { blackOrWhite: "white", background: "#cc142b", text: "#cc142b" },
+      { blackOrWhite: "white", background: "#00247d", text: "#00247d" }
+    ]
+  },
+  {
+    name: "Nicaragua",
+    colors: [
+      { blackOrWhite: "black", background: "#abcdec", text: "#a6cbeb" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#0067c6", text: "#0067c6" }
+    ]
+  },
+  {
+    name: "Niger",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "black", background: "#0db02b", text: "#0db02b" },
+      { blackOrWhite: "white", background: "#e05206", text: "#e05206" }
+    ]
+  },
+  {
+    name: "Norway",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#002868", text: "#002868" },
+      { blackOrWhite: "white", background: "#ef2b2d", text: "#ef2b2d" }
+    ]
+  },
+  {
+    name: "Oman",
+    colors: [
+      { blackOrWhite: "white", background: "#008000", text: "#008000" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#db161b", text: "#db161b" }
+    ]
+  },
+  {
+    name: "Pakistan",
+    colors: [
+      { blackOrWhite: "black", background: "#82a18f", text: "#82a18f" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#01411c", text: "#01411c" }
+    ]
+  },
+  {
+    name: "Palau",
+    colors: [
+      { blackOrWhite: "black", background: "#d4d233", text: "#cecc31" },
+      { blackOrWhite: "black", background: "#ffde00", text: "#e3c600" },
+      { blackOrWhite: "black", background: "#4aadd6", text: "#4aadd6" }
+    ]
+  },
+  {
+    name: "State of Palestine",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#007a3d", text: "#007a3d" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" }
+    ]
+  },
+  {
+    name: "Panama",
+    colors: [
+      { blackOrWhite: "white", background: "#d21034", text: "#d21034" },
+      { blackOrWhite: "white", background: "#005293", text: "#005293" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" }
+    ]
+  },
+  {
+    name: "Papua New Guinea",
+    colors: [
+      { blackOrWhite: "black", background: "#fcd016", text: "#ecc314" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" }
+    ]
+  },
+  {
+    name: "Paraguay",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#0038a8", text: "#0038a8" },
+      { blackOrWhite: "white", background: "#d52b1e", text: "#d52b1e" }
+    ]
+  },
+  {
+    name: "Philippines",
+    colors: [
+      { blackOrWhite: "black", background: "#f9f900", text: "#cdcd00" },
+      { blackOrWhite: "white", background: "#0038a8", text: "#0038a8" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" }
+    ]
+  },
+  {
+    name: "Portugal",
+    colors: [
+      { blackOrWhite: "black", background: "#959e01", text: "#959e01" },
+      { blackOrWhite: "white", background: "#006600", text: "#006600" },
+      { blackOrWhite: "white", background: "#ff0000", text: "#ff0000" }
+    ]
+  },
+  {
+    name: "Qatar",
+    colors: [
+      { blackOrWhite: "white", background: "#b2657d", text: "#b2657d" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#8d1b3d", text: "#8d1b3d" }
+    ]
+  },
+  {
+    name: "Russia",
+    colors: [
+      { blackOrWhite: "white", background: "#0039a6", text: "#0039a6" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#d52b1e", text: "#d52b1e" }
+    ]
+  },
+  {
+    name: "Rwanda",
+    colors: [
+      { blackOrWhite: "white", background: "#20603d", text: "#20603d" },
+      { blackOrWhite: "black", background: "#fad201", text: "#e9c401" },
+      { blackOrWhite: "black", background: "#00a1de", text: "#00a1de" }
+    ]
+  },
+  {
+    name: "Saint Kitts and Nevis",
+    colors: [
+      { blackOrWhite: "black", background: "#009e49", text: "#009e49" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" }
+    ]
+  },
+  {
+    name: "Saint Lucia",
+    colors: [
+      { blackOrWhite: "black", background: "#e7f3f3", text: "#333333" },
+      { blackOrWhite: "black", background: "#fcd116", text: "#ebc314" },
+      { blackOrWhite: "black", background: "#66ccff", text: "#66ccff" }
+    ]
+  },
+  {
+    name: "Saint Vincent and the Grenadines",
+    colors: [
+      { blackOrWhite: "white", background: "#0072c6", text: "#0072c6" },
+      { blackOrWhite: "black", background: "#009e60", text: "#009e60" },
+      { blackOrWhite: "black", background: "#fcd116", text: "#ebc314" }
+    ]
+  },
+  {
+    name: "Samoa",
+    colors: [
+      { blackOrWhite: "black", background: "#edf1f6", text: "#b4c9dc" },
+      { blackOrWhite: "white", background: "#002b7f", text: "#002b7f" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" }
+    ]
+  },
+  {
+    name: "San Marino",
+    colors: [
+      { blackOrWhite: "white", background: "#86681d", text: "#86681d" },
+      { blackOrWhite: "black", background: "#5eb6e4", text: "#5eb6e4" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" }
+    ]
+  },
+  {
+    name: "São Tomé and Príncipe",
+    colors: [
+      { blackOrWhite: "white", background: "#d21034", text: "#d21034" },
+      { blackOrWhite: "black", background: "#ffce00", text: "#efc100" },
+      { blackOrWhite: "black", background: "#12ad2b", text: "#12ad2b" }
+    ]
+  },
+  {
+    name: "Saudi Arabia",
+    colors: [
+      { blackOrWhite: "black", background: "#4c9872", text: "#4c9872" },
+      { blackOrWhite: "black", background: "#e7f4ed", text: "#333333" },
+      { blackOrWhite: "white", background: "#006c35", text: "#006c35" }
+    ]
+  },
+  {
+    name: "Senegal",
+    colors: [
+      { blackOrWhite: "black", background: "#fdef42", text: "#d6ca36" },
+      { blackOrWhite: "white", background: "#e31b23", text: "#e31b23" },
+      { blackOrWhite: "white", background: "#00853f", text: "#00853f" }
+    ]
+  },
+  {
+    name: "Serbia",
+    colors: [
+      { blackOrWhite: "black", background: "#cf9e2e", text: "#cf9e2e" },
+      { blackOrWhite: "white", background: "#0c4076", text: "#0c4076" },
+      { blackOrWhite: "white", background: "#c6363c", text: "#c6363c" }
+    ]
+  },
+  {
+    name: "Seychelles",
+    colors: [
+      { blackOrWhite: "black", background: "#fcd856", text: "#e6c440" },
+      { blackOrWhite: "white", background: "#003f87", text: "#003f87" },
+      { blackOrWhite: "white", background: "#d62828", text: "#d62828" }
+    ]
+  },
+  {
+    name: "Sierra Leone",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#0072c6", text: "#0072c6" },
+      { blackOrWhite: "black", background: "#1eb53a", text: "#1eb53a" }
+    ]
+  },
+  {
+    name: "Singapore",
+    colors: [
+      { blackOrWhite: "black", background: "#f58c94", text: "#f58c94" },
+      { blackOrWhite: "white", background: "#ed2939", text: "#ed2939" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" }
+    ]
+  },
+  {
+    name: "Slovakia",
+    colors: [
+      { blackOrWhite: "white", background: "#0b4ea2", text: "#0b4ea2" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#ee1c25", text: "#ee1c25" }
+    ]
+  },
+  {
+    name: "Slovenia",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#005da4", text: "#005da4" },
+      { blackOrWhite: "white", background: "#ed1c24", text: "#ed1c24" }
+    ]
+  },
+  {
+    name: "Solomon Islands",
+    colors: [
+      { blackOrWhite: "black", background: "#fcd116", text: "#ebc314" },
+      { blackOrWhite: "white", background: "#0051ba", text: "#0051ba" },
+      { blackOrWhite: "white", background: "#215b33", text: "#215b33" }
+    ]
+  },
+  {
+    name: "South Africa",
+    colors: [
+      { blackOrWhite: "white", background: "#002395", text: "#002395" },
+      { blackOrWhite: "white", background: "#de3831", text: "#de3831" },
+      { blackOrWhite: "white", background: "#007a4d", text: "#007a4d" }
+    ]
+  },
+  {
+    name: "South Sudan",
+    colors: [
+      { blackOrWhite: "white", background: "#0f47af", text: "#0f47af" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" },
+      { blackOrWhite: "white", background: "#078930", text: "#078930" }
+    ]
+  },
+  {
+    name: "Spain",
+    colors: [
+      { blackOrWhite: "white", background: "#975c11", text: "#975c11" },
+      { blackOrWhite: "black", background: "#ffc400", text: "#f7be00" },
+      { blackOrWhite: "white", background: "#c60b1e", text: "#c60b1e" }
+    ]
+  },
+  {
+    name: "Sri Lanka",
+    colors: [
+      { blackOrWhite: "white", background: "#005641", text: "#005641" },
+      { blackOrWhite: "white", background: "#8d2029", text: "#8d2029" },
+      { blackOrWhite: "black", background: "#feb700", text: "#feb700" }
+    ]
+  },
+  {
+    name: "Sudan",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#d21034", text: "#d21034" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" }
+    ]
+  },
+  {
+    name: "Suriname",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#b40a2d", text: "#b40a2d" },
+      { blackOrWhite: "white", background: "#377e3f", text: "#377e3f" }
+    ]
+  },
+  {
+    name: "Swaziland",
+    colors: [
+      { blackOrWhite: "black", background: "#fed800", text: "#e7c400" },
+      { blackOrWhite: "white", background: "#b10c0c", text: "#b10c0c" },
+      { blackOrWhite: "white", background: "#3e5eb9", text: "#3e5eb9" }
+    ]
+  },
+  {
+    name: "Switzerland",
+    colors: [
+      { blackOrWhite: "black", background: "#ff6060", text: "#ff6060" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#ff0000", text: "#ff0000" }
+    ]
+  },
+  {
+    name: "Syria",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" }
+    ]
+  },
+  {
+    name: "Tajikistan",
+    colors: [
+      { blackOrWhite: "white", background: "#006600", text: "#006600" },
+      { blackOrWhite: "white", background: "#cc0000", text: "#cc0000" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" }
+    ]
+  },
+  {
+    name: "Tanzania",
+    colors: [
+      { blackOrWhite: "black", background: "#00a3dd", text: "#00a3dd" },
+      { blackOrWhite: "black", background: "#1eb53a", text: "#1eb53a" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" }
+    ]
+  },
+  {
+    name: "Thailand",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#241d4f", text: "#241d4f" },
+      { blackOrWhite: "white", background: "#ed1c24", text: "#ed1c24" }
+    ]
+  },
+  {
+    name: "Togo",
+    colors: [
+      { blackOrWhite: "white", background: "#d21034", text: "#d21034" },
+      { blackOrWhite: "black", background: "#ffce00", text: "#efc100" },
+      { blackOrWhite: "white", background: "#006a4e", text: "#006a4e" }
+    ]
+  },
+  {
+    name: "Tonga",
+    colors: [
+      { blackOrWhite: "white", background: "#d65555", text: "#d65555" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#c10000", text: "#c10000" }
+    ]
+  },
+  {
+    name: "Trinidad and Tobago",
+    colors: [
+      { blackOrWhite: "black", background: "#f7eef7", text: "#dfbcdf" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" }
+    ]
+  },
+  {
+    name: "Tunisia",
+    colors: [
+      { blackOrWhite: "black", background: "#f16c77", text: "#f16c77" },
+      { blackOrWhite: "black", background: "#ffecec", text: "#ffb3b3" },
+      { blackOrWhite: "white", background: "#e70013", text: "#e70013" }
+    ]
+  },
+  {
+    name: "Turkey",
+    colors: [
+      { blackOrWhite: "black", background: "#ef7279", text: "#ef7279" },
+      { blackOrWhite: "black", background: "#ffecec", text: "#ffb3b3" },
+      { blackOrWhite: "white", background: "#e30a17", text: "#e30a17" }
+    ]
+  },
+  {
+    name: "Turkmenistan",
+    colors: [
+      { blackOrWhite: "white", background: "#b47134", text: "#b47134" },
+      { blackOrWhite: "white", background: "#c93745", text: "#c93745" },
+      { blackOrWhite: "black", background: "#28ae66", text: "#28ae66" }
+    ]
+  },
+  {
+    name: "Tuvalu",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#cf142b", text: "#cf142b" },
+      { blackOrWhite: "black", background: "#5b97b1", text: "#5b97b1" }
+    ]
+  },
+  {
+    name: "Uganda",
+    colors: [
+      { blackOrWhite: "white", background: "#d90000", text: "#d90000" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" },
+      { blackOrWhite: "black", background: "#fcdc04", text: "#e3c603" }
+    ]
+  },
+  {
+    name: "United Arab Emirates",
+    colors: [
+      { blackOrWhite: "white", background: "#000000", text: "#000000" },
+      { blackOrWhite: "white", background: "#00732f", text: "#00732f" },
+      { blackOrWhite: "white", background: "#ff0000", text: "#ff0000" }
+    ]
+  },
+  {
+    name: "United Kingdom",
+    colors: [
+      { blackOrWhite: "black", background: "#f3c4ca", text: "#f1b8bf" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#cf142b", text: "#cf142b" }
+    ]
+  },
+  {
+    name: "United States",
+    colors: [
+      { blackOrWhite: "white", background: "#3c3b6e", text: "#3c3b6e" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#b22234", text: "#b22234" }
+    ]
+  },
+  {
+    name: "Uruguay",
+    colors: [
+      { blackOrWhite: "black", background: "#c6d3ec", text: "#b6c7e7" },
+      { blackOrWhite: "black", background: "#9e830e", text: "#9e830e" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" }
+    ]
+  },
+  {
+    name: "Uzbekistan",
+    colors: [
+      { blackOrWhite: "black", background: "#0099b5", text: "#0099b5" },
+      { blackOrWhite: "black", background: "#1eb53a", text: "#1eb53a" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" }
+    ]
+  },
+  {
+    name: "Vanuatu",
+    colors: [
+      { blackOrWhite: "white", background: "#010100", text: "#010100" },
+      { blackOrWhite: "white", background: "#d21034", text: "#d21034" },
+      { blackOrWhite: "white", background: "#009543", text: "#009543" }
+    ]
+  },
+  {
+    name: "Vatican City",
+    colors: [
+      { blackOrWhite: "black", background: "#d1d0ce", text: "#333333" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "black", background: "#ffe000", text: "#e2c600" }
+    ]
+  },
+  {
+    name: "Venezuela",
+    colors: [
+      { blackOrWhite: "white", background: "#00247d", text: "#00247d" },
+      { blackOrWhite: "black", background: "#ffcc00", text: "#f1c100" },
+      { blackOrWhite: "white", background: "#cf142b", text: "#cf142b" }
+    ]
+  },
+  {
+    name: "Yemen",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" },
+      { blackOrWhite: "white", background: "#ce1126", text: "#ce1126" }
+    ]
+  },
+  {
+    name: "Zambia",
+    colors: [
+      { blackOrWhite: "white", background: "#de2010", text: "#de2010" },
+      { blackOrWhite: "black", background: "#ef7d00", text: "#ef7d00" },
+      { blackOrWhite: "white", background: "#198a00", text: "#198a00" }
+    ]
+  },
+  {
+    name: "Zimbabwe",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#de2010", text: "#de2010" },
+      { blackOrWhite: "white", background: "#319208", text: "#319208" }
+    ]
+  },
+  {
+    name: "Abkhazia",
+    colors: [
+      { blackOrWhite: "white", background: "#c8312a", text: "#c8312a" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "black", background: "#00993e", text: "#00993e" }
+    ]
+  },
+  {
+    name: "Cook Islands",
+    colors: [
+      { blackOrWhite: "white", background: "#cf142b", text: "#cf142b" },
+      { blackOrWhite: "black", background: "#f0f0f8", text: "#c4c4e2" },
+      { blackOrWhite: "white", background: "#00247d", text: "#00247d" }
+    ]
+  },
+  {
+    name: "Kosovo",
+    colors: [
+      { blackOrWhite: "black", background: "#ecf1fa", text: "#b1c8ed" },
+      { blackOrWhite: "black", background: "#d0a650", text: "#d0a650" },
+      { blackOrWhite: "white", background: "#244aa5", text: "#244aa5" }
+    ]
+  },
+  {
+    name: "Nagorno-Karabakh Republic",
+    colors: [
+      { blackOrWhite: "white", background: "#0033a0", text: "#0033a0" },
+      { blackOrWhite: "white", background: "#d90012", text: "#d90012" },
+      { blackOrWhite: "black", background: "#f2a800", text: "#f2a800" }
+    ]
+  },
+  {
+    name: "Niue",
+    colors: [
+      { blackOrWhite: "white", background: "#cf142b", text: "#cf142b" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "black", background: "#fcd116", text: "#ebc314" }
+    ]
+  },
+  {
+    name: "Northern Cyprus",
+    colors: [
+      { blackOrWhite: "black", background: "#ea4b55", text: "#ea4b55" },
+      { blackOrWhite: "white", background: "#e30a17", text: "#e30a17" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" }
+    ]
+  },
+  {
+    name: "Sahrawi Arab Democratic Republic",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#007a3d", text: "#007a3d" },
+      { blackOrWhite: "white", background: "#000000", text: "#000000" }
+    ]
+  },
+  {
+    name: "Somaliland",
+    colors: [
+      { blackOrWhite: "black", background: "#9b9f9c", text: "#9b9f9c" },
+      { blackOrWhite: "white", background: "#006d21", text: "#006d21" },
+      { blackOrWhite: "white", background: "#020202", text: "#020202" }
+    ]
+  },
+  {
+    name: "South Ossetia",
+    colors: [
+      { blackOrWhite: "white", background: "#ff0000", text: "#ff0000" },
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "black", background: "#ffdf00", text: "#e3c600" }
+    ]
+  },
+  {
+    name: "Taiwan",
+    colors: [
+      { blackOrWhite: "black", background: "#f1f1f1", text: "#333333" },
+      { blackOrWhite: "white", background: "#000095", text: "#000095" },
+      { blackOrWhite: "white", background: "#fe0000", text: "#fe0000" }
+    ]
+  },
+  {
+    name: "Transnistria",
+    colors: [
+      { blackOrWhite: "white", background: "#6f4d1a", text: "#6f4d1a" },
+      { blackOrWhite: "black", background: "#009933", text: "#009933" },
+      { blackOrWhite: "white", background: "#de0000", text: "#de0000" }
+    ]
+  }
 ];

--- a/packages/dsi-logo-maker/utils/graphics.js
+++ b/packages/dsi-logo-maker/utils/graphics.js
@@ -31,7 +31,7 @@ function textContrastColor(bgColor) {
   const g = parseInt(color.substring(2, 4), 16); // hexToG
   const b = parseInt(color.substring(4, 6), 16); // hexToB
   const uicolors = [r / 255, g / 255, b / 255];
-  const c = uicolors.map((col) => {
+  const c = uicolors.map(col => {
     if (col <= 0.03928) {
       return col / 12.92;
     }
@@ -44,6 +44,6 @@ function textContrastColor(bgColor) {
 export function genColorObject(color) {
   return {
     background: color,
-    blackOrWhite: textContrastColor(color),
+    blackOrWhite: textContrastColor(color)
   };
 }

--- a/packages/dsi-logo-maker/utils/hooks.js
+++ b/packages/dsi-logo-maker/utils/hooks.js
@@ -15,7 +15,7 @@ export const useDrawLoop = (isPlaying, duration) => {
       return;
     }
 
-    const draw = (t) => {
+    const draw = t => {
       const timestamp = t || new Date().getTime();
       if (!starttime.current) {
         starttime.current = timestamp;
@@ -39,10 +39,10 @@ export const useDrawLoop = (isPlaying, duration) => {
 /**
   A hook to load an opentype font
 **/
-export const useLoadedOpentypeFont = (name) => {
+export const useLoadedOpentypeFont = name => {
   const [font, setFont] = useState(null);
   useMemo(() => {
-    loadOpentypeFont(name, (f) => {
+    loadOpentypeFont(name, f => {
       setFont(f);
     });
   }, [name]);

--- a/packages/dsi-logo-maker/utils/seeds.js
+++ b/packages/dsi-logo-maker/utils/seeds.js
@@ -1,9 +1,9 @@
-export const stringToSeed = (str) => {
+export const stringToSeed = str => {
   return str.length === 0
     ? 0
     : str
         .split("")
-        .map((c) => c.charCodeAt())
+        .map(c => c.charCodeAt())
         .reduce((a, b) => a + b);
 };
 
@@ -15,12 +15,12 @@ export const buildSeeds = (
   if (seedMode === "From Text") {
     return {
       seedDistribution: stringToSeed(text),
-      seedOffset: text.length,
+      seedOffset: text.length
     };
   } else {
     return {
       seedDistribution: seedForDistribution,
-      seedOffset: seedForOffset,
+      seedOffset: seedForOffset
     };
   }
 };

--- a/packages/engine-canvas/index.js
+++ b/packages/engine-canvas/index.js
@@ -10,7 +10,7 @@ export const run = (functionName, func, values, config) => {
   const mechanic = new Mechanic(func.settings, values, config);
 
   let isElAdded = false;
-  const onFrame = (el) => {
+  const onFrame = el => {
     if (!isElAdded) {
       isElAdded = true;
       root.appendChild(el);
@@ -29,7 +29,7 @@ export const run = (functionName, func, values, config) => {
       mechanic.download(name || functionName);
     }
   };
-  const onSetState = async (obj) => {
+  const onSetState = async obj => {
     mechanic.setState(obj);
   };
 
@@ -39,8 +39,8 @@ export const run = (functionName, func, values, config) => {
       frame: onFrame,
       done: onDone,
       state: mechanic.functionState,
-      setState: onSetState,
-    },
+      setState: onSetState
+    }
   });
   return mechanic;
 };

--- a/packages/engine-p5/index.js
+++ b/packages/engine-p5/index.js
@@ -16,28 +16,28 @@ export const run = (functionName, func, values, config) => {
       mechanic.frame(root.childNodes[0]);
     }
   };
-  const onDone = async (name) => {
+  const onDone = async name => {
     p5Sketch.noLoop();
     if (!isPreview) {
       await mechanic.done(root.childNodes[0]);
       mechanic.download(name || functionName);
     }
   };
-  const onSetState = async (obj) => {
+  const onSetState = async obj => {
     mechanic.setState(obj);
   };
 
   p5Sketch = new p5(
-    (sketch) =>
+    sketch =>
       func.handler({
         inputs: mechanic.values,
         mechanic: {
           frame: onFrame,
           done: onDone,
           state: mechanic.functionState,
-          setState: onSetState,
+          setState: onSetState
         },
-        sketch,
+        sketch
       }),
     root
   );

--- a/packages/engine-react/index.js
+++ b/packages/engine-react/index.js
@@ -15,13 +15,13 @@ export const run = (functionName, func, values, config) => {
       mechanic.frame(root.childNodes[0], { head });
     }
   };
-  const onDone = async (name) => {
+  const onDone = async name => {
     if (!isPreview) {
       await mechanic.done(root.childNodes[0], { head });
       mechanic.download(name || functionName);
     }
   };
-  const onSetState = async (obj) => {
+  const onSetState = async obj => {
     mechanic.setState(obj);
   };
   render(
@@ -31,7 +31,7 @@ export const run = (functionName, func, values, config) => {
         frame: onFrame,
         done: onDone,
         state: mechanic.functionState,
-        setState: onSetState,
+        setState: onSetState
       }}
     />,
     root

--- a/packages/engine-svg/index.js
+++ b/packages/engine-svg/index.js
@@ -9,7 +9,7 @@ export const run = (functionName, func, values, config) => {
   root.innerHTML = "";
 
   const mechanic = new Mechanic(func.settings, values, config);
-  const onFrame = (el) => {
+  const onFrame = el => {
     // Pending virtual-dom approach
     root.innerHTML = el.trim();
     if (!isPreview) {
@@ -23,7 +23,7 @@ export const run = (functionName, func, values, config) => {
       mechanic.download(name || functionName);
     }
   };
-  const onSetState = async (obj) => {
+  const onSetState = async obj => {
     mechanic.setState(obj);
   };
 
@@ -33,8 +33,8 @@ export const run = (functionName, func, values, config) => {
       frame: onFrame,
       done: onDone,
       state: mechanic.functionState,
-      setState: onSetState,
-    },
+      setState: onSetState
+    }
   });
   return mechanic;
 };

--- a/packages/ui-components/app/index.js
+++ b/packages/ui-components/app/index.js
@@ -45,7 +45,8 @@ const App = () => {
             type: "text",
             label: "The Text",
             default: "Hi",
-            validation: value => (value.length < 15 ? null : "Length must be less than 15")
+            validation: value =>
+              value.length < 15 ? null : "Length must be less than 15"
           }}
           onChange={handleChange}
         />
@@ -69,7 +70,8 @@ const App = () => {
           attributes={{
             type: "number",
             default: 400,
-            validation: value => (value < 450 || value > 455 ? null : "Not in range")
+            validation: value =>
+              value < 450 || value > 455 ? null : "Not in range"
           }}
           onChange={handleChange}
         />
@@ -84,7 +86,8 @@ const App = () => {
             min: 400,
             max: 500,
             step: 10,
-            validation: value => (value < 430 || value > 465 ? null : "Not in range")
+            validation: value =>
+              value < 430 || value > 465 ? null : "Not in range"
           }}
           onChange={handleChange}
         />
@@ -100,7 +103,8 @@ const App = () => {
             max: 500,
             step: 0.5,
             slider: true,
-            validation: value => (value < 430 || value > 465 ? null : "Not in range")
+            validation: value =>
+              value < 430 || value > 465 ? null : "Not in range"
           }}
           onChange={handleChange}
         />
@@ -113,7 +117,8 @@ const App = () => {
             type: "color",
             model: "hex",
             default: "#f62696",
-            validation: value => (value[1] === "f" ? null : "Should have high red channel")
+            validation: value =>
+              value[1] === "f" ? null : "Should have high red channel"
           }}
           onChange={handleChange}
         />
@@ -138,7 +143,8 @@ const App = () => {
             type: "text",
             default: "Option 1",
             options: ["Option 1", "Option 2", "Option 3"],
-            validation: value => (value === "Option 1" ? null : "Should be Option 1")
+            validation: value =>
+              value === "Option 1" ? null : "Should be Option 1"
           }}
           onChange={handleChange}
         />
@@ -380,13 +386,23 @@ const App = () => {
           placeholder="Write... "
           min="100"
           max="200"
-          step="5"></NumberInput>
+          step="5"
+        ></NumberInput>
       </div>
       <div className={css.simpleBlock}>
-        <NumberInput label="Slider Number Input" slider min="100" max="200" step="5"></NumberInput>
+        <NumberInput
+          label="Slider Number Input"
+          slider
+          min="100"
+          max="200"
+          step="5"
+        ></NumberInput>
       </div>
       <div className={css.simpleBlock}>
-        <ColorInput label="Color Input" value="rgba(100, 200, 200,1)"></ColorInput>
+        <ColorInput
+          label="Color Input"
+          value="rgba(100, 200, 200,1)"
+        ></ColorInput>
       </div>
       <div className={css.simpleBlock}>
         <Select label="Select Input">

--- a/packages/ui-components/src/MechanicInput.js
+++ b/packages/ui-components/src/MechanicInput.js
@@ -6,12 +6,20 @@ import * as css from "./MechanicInput.module.css";
 import { TextInput } from "./input/TextInput.js";
 import { NumberInput } from "./input/NumberInput.js";
 import { BooleanInput } from "./input/BooleanInput.js";
+
 import { OptionInput } from "./input/OptionInput.js";
 import { ColorInput } from "./input/ColorInput.js";
 import { ImageInput } from "./input/ImageInput.js";
 import { uid } from "./uid.js";
 
-export const MechanicInput = ({ name, className, values, attributes, onChange, children }) => {
+export const MechanicInput = ({
+  name,
+  className,
+  values,
+  attributes,
+  onChange,
+  children
+}) => {
   const id = useRef(uid("mechanic-input"));
   const { type, label: _label, options, validation, editable } = attributes;
   const _default = attributes["default"];
@@ -19,7 +27,11 @@ export const MechanicInput = ({ name, className, values, attributes, onChange, c
 
   const value = values[name];
   const isEditable =
-    editable === undefined ? true : typeof editable === "function" ? !!editable(values) : editable;
+    editable === undefined
+      ? true
+      : typeof editable === "function"
+      ? !!editable(values)
+      : editable;
   const actualValue = value === undefined ? _default : value;
   const error = validation ? validation(actualValue) : null;
 
@@ -40,7 +52,8 @@ export const MechanicInput = ({ name, className, values, attributes, onChange, c
         invalid={error ? true : false}
         error={error}
         disabled={!isEditable}
-        onChange={onChange}>
+        onChange={onChange}
+      >
         {children}
       </OptionInput>
     );
@@ -59,7 +72,8 @@ export const MechanicInput = ({ name, className, values, attributes, onChange, c
         error={error}
         multiple={multiple}
         disabled={!isEditable}
-        onChange={onChange}>
+        onChange={onChange}
+      >
         {children}
       </ImageInput>
     );
@@ -76,7 +90,8 @@ export const MechanicInput = ({ name, className, values, attributes, onChange, c
         invalid={error ? true : false}
         error={error}
         disabled={!isEditable}
-        onChange={onChange}>
+        onChange={onChange}
+      >
         {children}
       </BooleanInput>
     );
@@ -95,7 +110,8 @@ export const MechanicInput = ({ name, className, values, attributes, onChange, c
         invalid={error ? true : false}
         error={error}
         disabled={!isEditable}
-        onChange={onChange}>
+        onChange={onChange}
+      >
         {children}
       </ColorInput>
     );
@@ -117,7 +133,8 @@ export const MechanicInput = ({ name, className, values, attributes, onChange, c
         min={min}
         max={max}
         step={step}
-        onChange={onChange}>
+        onChange={onChange}
+      >
         {children}
       </NumberInput>
     );
@@ -133,7 +150,8 @@ export const MechanicInput = ({ name, className, values, attributes, onChange, c
       invalid={error ? true : false}
       error={error}
       disabled={!isEditable}
-      onChange={onChange}>
+      onChange={onChange}
+    >
       {children}
     </TextInput>
   );

--- a/packages/ui-components/src/buttons/Button.js
+++ b/packages/ui-components/src/buttons/Button.js
@@ -48,7 +48,8 @@ export const Button = props => {
       onFocus={handleOnFocus}
       onBlur={handleOnBlur}
       disabled={disabled}
-      tabIndex={disabled ? "-1" : undefined}>
+      tabIndex={disabled ? "-1" : undefined}
+    >
       <span>{children}</span>
     </button>
   );

--- a/packages/ui-components/src/buttons/Toggle.js
+++ b/packages/ui-components/src/buttons/Toggle.js
@@ -42,7 +42,8 @@ export const Toggle = props => {
       onClick={onClick}
       onFocus={handleOnFocus}
       onBlur={handleOnBlur}
-      disabled={disabled}>
+      disabled={disabled}
+    >
       <div className={classnames(css.status, { [css.on]: status })} />
       <span className={css.label}>{children}</span>
     </button>

--- a/packages/ui-components/src/icons/index.js
+++ b/packages/ui-components/src/icons/index.js
@@ -8,7 +8,8 @@ export const Invalid = ({ width = 12, height = 20, ...otherProps }) => {
       viewBox="0 0 12 20"
       fill="none"
       {...otherProps}
-      xmlns="http://www.w3.org/2000/svg">
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <circle cx="6" cy="15.5" r="1.5" fill="currentColor" />
       <path
         d="M5 5C5 4.44772 5.44772 4 6 4V4C6.55228 4 7 4.44772 7 5V11C7 11.5523 6.55228 12 6 12V12C5.44772 12 5 11.5523 5 11V5Z"
@@ -26,7 +27,8 @@ export const Dropdown = ({ width = 20, height = 20, open, ...otherProps }) => {
       viewBox="0 0 20 20"
       fill="none"
       {...otherProps}
-      xmlns="http://www.w3.org/2000/svg">
+      xmlns="http://www.w3.org/2000/svg"
+    >
       {open ? (
         <path d="M10 7L16.9282 14.5L3.0718 14.5L10 7Z" fill="currentColor" />
       ) : (
@@ -44,9 +46,17 @@ export const Add = ({ width = 20, height = 20, ...otherProps }) => {
       viewBox="0 0 20 20"
       fill="none"
       {...otherProps}
-      xmlns="http://www.w3.org/2000/svg">
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <rect x="9" y="4" width="2" height="12" fill="currentColor" />
-      <rect x="16" y="9" width="2" height="12" transform="rotate(90 16 9)" fill="currentColor" />
+      <rect
+        x="16"
+        y="9"
+        width="2"
+        height="12"
+        transform="rotate(90 16 9)"
+        fill="currentColor"
+      />
     </svg>
   );
 };

--- a/packages/ui-components/src/index.js
+++ b/packages/ui-components/src/index.js
@@ -8,4 +8,8 @@ export { Select } from "./input/Select.js";
 export { OptionInput } from "./input/OptionInput.js";
 export { ImageInput } from "./input/ImageInput.js";
 export { MechanicInput } from "./MechanicInput.js";
-export { Dropdown as DropdownIcon, Invalid as InvalidIcon, Add as AddIcon } from "./icons/index.js";
+export {
+  Dropdown as DropdownIcon,
+  Invalid as InvalidIcon,
+  Add as AddIcon
+} from "./icons/index.js";

--- a/packages/ui-components/src/input/BooleanInput.js
+++ b/packages/ui-components/src/input/BooleanInput.js
@@ -49,7 +49,8 @@ export const BooleanInput = props => {
           onFocus={onFocus}
           onBlur={onBlur}
           aria-describedby={`error-${id}`}
-          aria-invalid={invalid}>
+          aria-invalid={invalid}
+        >
           {value ? "true" : "false"}
           {children}
         </Toggle>

--- a/packages/ui-components/src/input/ColorInput.js
+++ b/packages/ui-components/src/input/ColorInput.js
@@ -107,17 +107,23 @@ export const ColorInput = props => {
         aria-describedby={`error-${id}`}
         aria-invalid={invalid}
         onFocus={handleOnFocus}
-        onBlur={handleOnBlur}>
+        onBlur={handleOnBlur}
+      >
         <Button
           className={classnames(commonCss.button, css.button)}
           onClick={handleOnClick}
-          disabled={disabled}>
+          disabled={disabled}
+        >
           <span className={css.swatch} style={{ backgroundColor: value }} />
           <span className={css.value}>{value}</span>
         </Button>
         {picking && (
           <div className={css.popover}>
-            <ChromePicker className={css.chromePicker} color={value} onChange={handleOnChange} />
+            <ChromePicker
+              className={css.chromePicker}
+              color={value}
+              onChange={handleOnChange}
+            />
           </div>
         )}
         <div className={commonCss.suffix}>{invalid && <Invalid />}</div>

--- a/packages/ui-components/src/input/ColorInput.module.css
+++ b/packages/ui-components/src/input/ColorInput.module.css
@@ -18,7 +18,8 @@
 }
 
 .picking .button {
-  border-radius: var(--mechanic-input-height-half) var(--mechanic-input-height-half) 0 0;
+  border-radius: var(--mechanic-input-height-half)
+    var(--mechanic-input-height-half) 0 0;
 }
 
 .popover {
@@ -38,7 +39,8 @@
     border-bottom: 1px solid currentColor !important;
 
     /* border-top: none !important; */
-    border-radius: 0 0 var(--mechanic-input-height-half) var(--mechanic-input-height-half) !important;
+    border-radius: 0 0 var(--mechanic-input-height-half)
+      var(--mechanic-input-height-half) !important;
     padding: 0.5em;
     overflow: hidden;
     box-sizing: border-box !important;

--- a/packages/ui-components/src/input/ImageInput.js
+++ b/packages/ui-components/src/input/ImageInput.js
@@ -46,7 +46,10 @@ export const ImageInput = props => {
   const [focus, setFocus] = useState(false);
   const [preview, setPreview] = useState(null);
 
-  const handleChangePreview = useCallback(value => setPreview(value), [setPreview]);
+  const handleChangePreview = useCallback(
+    value => setPreview(value),
+    [setPreview]
+  );
 
   const handleOnChange = event => {
     const { name, files } = event.target;
@@ -136,7 +139,8 @@ export const ImageInput = props => {
             onFocus={handleOnFocus}
             onBlur={handleOnBlur}
             onClick={handleButtonClick}
-            disabled={disabled}>
+            disabled={disabled}
+          >
             <Add className={css.plus} />
           </button>
         </div>

--- a/packages/ui-components/src/input/NumberInput.js
+++ b/packages/ui-components/src/input/NumberInput.js
@@ -35,7 +35,10 @@ export const NumberInput = props => {
   const handleOnChange = event => {
     const { name, value } = event.target;
     const parsedValue = value === "" ? 0 : parseFloat(value);
-    const constrainedValue = Math.min(max || Infinity, Math.max(min || -Infinity, value));
+    const constrainedValue = Math.min(
+      max || Infinity,
+      Math.max(min || -Infinity, value)
+    );
     onChange && onChange(event, name, constrainedValue);
   };
 
@@ -116,7 +119,9 @@ export const NumberInput = props => {
             aria-describedby={`error-${id}`}
             aria-invalid={invalid}
           />
-          {invalid && <div className={classnames(css.background, commonCss.background)} />}
+          {invalid && (
+            <div className={classnames(css.background, commonCss.background)} />
+          )}
         </div>
       ) : (
         <div className={commonCss.inputWrapper}>

--- a/packages/ui-components/src/input/NumberInput.module.css
+++ b/packages/ui-components/src/input/NumberInput.module.css
@@ -16,7 +16,8 @@
   box-sizing: border-box;
   align-items: center;
   height: var(--mechanic-input-height);
-  padding: 0 var(--mechanic-input-height-eighth) 0 var(--mechanic-input-height-quart);
+  padding: 0 var(--mechanic-input-height-eighth) 0
+    var(--mechanic-input-height-quart);
   background-color: var(--mechanic-background);
   border: 2px solid transparent;
   color: currentColor;

--- a/packages/ui-components/src/input/OptionInput.js
+++ b/packages/ui-components/src/input/OptionInput.js
@@ -26,10 +26,13 @@ export const OptionInput = props => {
     onBlur
   } = props;
 
-  const arrayOfOptions = Array.isArray(options) ? options : Object.keys(options);
+  const arrayOfOptions = Array.isArray(options)
+    ? options
+    : Object.keys(options);
 
   const handleOnChange = event => {
-    const value = type === "number" ? parseFloat(event.target.value) : event.target.value;
+    const value =
+      type === "number" ? parseFloat(event.target.value) : event.target.value;
     onChange(event, name, value);
   };
 
@@ -51,7 +54,8 @@ export const OptionInput = props => {
       placeholder={placeholder}
       onChange={handleOnChange}
       onFocus={onFocus}
-      onBlur={onBlur}>
+      onBlur={onBlur}
+    >
       {arrayOfOptions.map(value => (
         <option key={`option-${name}-${value}`} value={value}>
           {value}

--- a/packages/ui-components/src/input/Select.js
+++ b/packages/ui-components/src/input/Select.js
@@ -69,7 +69,8 @@ export const Select = props => {
           onBlur={handleOnBlur}
           aria-required={required}
           aria-describedby={`error-${id}`}
-          aria-invalid={invalid}>
+          aria-invalid={invalid}
+        >
           <option disabled>{placeholder}</option>
           {children}
         </select>

--- a/packages/ui-components/src/uid.js
+++ b/packages/ui-components/src/uid.js
@@ -2,4 +2,5 @@
  * Generate a UUID to use in component ID attributes
  * @param {string} prefix - Optional string prefix for the UUID
  */
-export const uid = (prefix = "comp") => prefix + "-" + Math.random().toString(36).substring(2, 16);
+export const uid = (prefix = "comp") =>
+  prefix + "-" + Math.random().toString(36).substring(2, 16);

--- a/packages/utils/index.js
+++ b/packages/utils/index.js
@@ -50,16 +50,17 @@ const mechanicSpinner = ora({ spinner: mechanicSpinnerSettings });
 
 mechanicSpinner.succeed = text =>
   mechanicSpinner.stopAndPersist({ text, symbol: chalk.bgGreen(" ✔ ") });
-mechanicSpinner.fail = text => mechanicSpinner.stopAndPersist({ text, symbol: chalk.bgRed(" ✖ ") });
+mechanicSpinner.fail = text =>
+  mechanicSpinner.stopAndPersist({ text, symbol: chalk.bgRed(" ✖ ") });
 mechanicSpinner.warn = text =>
   mechanicSpinner.stopAndPersist({ text, symbol: chalk.bgYellow(" ⚠ ") });
 
 const mechanicLogo = `${red("MECHANIC")}\n${blue("MECHANIC")}`;
 const mechanicLogoInverse = `${blue("MECHANIC")}\n${red("MECHANIC")}`;
 
-const dsiLogo = `${white("TIONAL")}${red("DESIGN")}${blue("S")}\n${blue("YSTEMS")}${white(
-  "INTERNA"
-)}`;
+const dsiLogo = `${white("TIONAL")}${red("DESIGN")}${blue("S")}\n${blue(
+  "YSTEMS"
+)}${white("INTERNA")}`;
 
 module.exports = {
   spinners: {


### PR DESCRIPTION
Did a little choring formatting all files with the recent addition of a prettier config. Other recent PRs had a lot of formatting changes that made it a bit difficult to follow which were format changes and which were for the PR. Let's get this over with!

This PR:
- Adds prettier commands at the root of the monorepo
- Runs prettier formatting across the repo
- Replaces setting `jsxBracketSameLine` (cause it's [deprecated](https://prettier.io/docs/en/options.html#deprecated-jsx-brackets)) with `bracketSameLine`. Because of the deprecation, I had a weird situation where the prettier command didn't leave the bracket in the same line, but the prettier from VSCode did! I changed it to `false`cause I noticed in Lucas' PRs that the bracket was left in another line, and I like it better I think :) .