### PR TITLE
fix: dsi-logo-maker/textAndImageSVG

### DIFF
--- a/packages/dsi-logo-maker/CHANGELOG.md
+++ b/packages/dsi-logo-maker/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated all design functions to use `opentype.js` for rendering text to `<path />` elements or canvas.
 - Updated all design functions with a string input with options for `thin` and `regular` versions of F Grotesk
 
+### Fixed
+
+- Fixed exporting issue for `textAndImageSVG` function.
+
 ## 1.1.0 -2021-09-29
 
 ### Changed

--- a/packages/dsi-logo-maker/functions/textAndImageSVG/index.js
+++ b/packages/dsi-logo-maker/functions/textAndImageSVG/index.js
@@ -3,7 +3,7 @@ import { getColors } from "../../utils/graphics";
 import {
   computeBaseBricks,
   computeBlockGeometry,
-  computeBlock,
+  computeBlock
 } from "../../utils/blocks";
 import { useLoadedOpentypeFont } from "../../utils/hooks";
 import { Block } from "../../utils/blocks-components";
@@ -18,13 +18,13 @@ export const handler = ({ inputs, mechanic }) => {
     rows,
     colors: colorsString,
     offset,
-    image,
+    image
   } = inputs;
   const { done } = mechanic;
 
   const [href, setHref] = useState("");
 
-  const words = text.split(" ").map((s) => s.toUpperCase());
+  const words = text.split(" ").map(s => s.toUpperCase());
   const colors = getColors("Custom Colors", null, colorsString.split(","));
   const height = Math.floor((width / ratio) * rows);
   const font = useLoadedOpentypeFont(fontMode);
@@ -43,10 +43,10 @@ export const handler = ({ inputs, mechanic }) => {
   }, [font, image]);
 
   useEffect(() => {
-    if (!image || href !== "") {
+    if (font && (!image || href !== "")) {
       done();
     }
-  }, [image, href]);
+  }, [font, image, href]);
 
   if (!font) {
     return null;
@@ -74,7 +74,7 @@ export const inputs = {
   width: {
     type: "number",
     default: 500,
-    min: 100,
+    min: 100
   },
   ratio: {
     type: "number",
@@ -82,35 +82,35 @@ export const inputs = {
     max: 20,
     slider: true,
     min: 6,
-    step: 1,
+    step: 1
   },
   fontMode: {
     type: "text",
     options: {
       "F Grotesk Thin": "FGroteskThin-Regular.otf",
-      "F Grotesk": "FGrotesk-Regular.otf",
+      "F Grotesk": "FGrotesk-Regular.otf"
     },
-    default: "F Grotesk Thin",
+    default: "F Grotesk Thin"
   },
   text: {
     type: "text",
-    default: "Whatever you want",
+    default: "Whatever you want"
   },
   columns: {
     type: "number",
     default: 13,
     min: 1,
-    step: 1,
+    step: 1
   },
   rows: {
     type: "number",
     default: 2,
     min: 1,
-    step: 1,
+    step: 1
   },
   colors: {
     type: "text",
-    default: "#11457e,#d7141a,#f1f1f1",
+    default: "#11457e,#d7141a,#f1f1f1"
   },
   offset: {
     type: "number",
@@ -118,21 +118,21 @@ export const inputs = {
     min: 0,
     max: 1,
     step: 0.05,
-    slider: true,
+    slider: true
   },
   image: {
     type: "image",
-    multiple: false,
-  },
+    multiple: false
+  }
 };
 
 export const presets = {
   bigger: {
     width: 500,
-    height: 500,
-  },
+    height: 500
+  }
 };
 
 export const settings = {
-  engine: require("@mechanic-design/engine-react"),
+  engine: require("@mechanic-design/engine-react")
 };


### PR DESCRIPTION
While checking #157, I noticed the textAndImageSVG function in dsi-logo-maker didn't export. This was because of a separate issue, where a done call would be done when the function renders null. This fixes that little issue.