### PR TITLE
fix: extra line gets logged when finishing running create-mechanic

### DIFF
--- a/packages/create-mechanic/script-content.js
+++ b/packages/create-mechanic/script-content.js
@@ -109,8 +109,7 @@ To start you now can run:
       : !installation.success
       ? `\n> \`${installation.installingMethod} install\``
       : ""
-  }
-> ${
+  }${
     !installation
       ? "\n> `npm run dev` or `yarn run dev`"
       : `\`${installation.installingMethod} run dev\``
@@ -132,8 +131,7 @@ To start you now can run:${
       : !installation.success
       ? `\n> \`${installation.installingMethod} install\``
       : ""
-  }
-> ${
+  }${
     !installation
       ? "\n> `npm run dev` or `yarn run dev`"
       : `\`${installation.installingMethod} run dev\``


### PR DESCRIPTION
Found another little issue. An extra line would get logged  because an extra one got added accidentally at some point. 

It was logging:
```
Done! Mechanic project created at my-project
To start you now can run:
> `cd my-project`
> `npm install` or `yarn install`
> 
> `npm run dev` or `yarn run dev`
```

And now:

```
Done! Mechanic project created at my-project
To start you now can run:
> `cd my-project-2`
> `npm install` or `yarn install`
> `npm run dev` or `yarn run dev`
```