### PR TITLE
Allow 10x steps by holding shift on number input

### DIFF
--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Holding down shift allows increases the step of the numeric input by 10
+
 ## 2.0.0-beta.9 - 2022-08-12
 
 ### Fixed

--- a/packages/ui-components/src/input/NumberInput.js
+++ b/packages/ui-components/src/input/NumberInput.js
@@ -1,7 +1,8 @@
-import React, { useRef, useState, useMemo } from "react";
+import React, { useRef, useState, useMemo, useEffect } from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
 import { uid } from "../uid.js";
+import { useShiftKey } from "../util/useShiftKey.js";
 import { Invalid } from "../icons/index.js";
 
 import * as commonCss from "../common.module.css";
@@ -31,6 +32,7 @@ export const NumberInput = props => {
     onBlur
   } = props;
   const [focus, setFocus] = useState(false);
+  const isShiftPressed = useShiftKey();
 
   const handleOnChange = event => {
     const { name, value } = event.target;
@@ -51,6 +53,14 @@ export const NumberInput = props => {
     onBlur && onBlur(event);
     setFocus(false);
   };
+
+  // When shift is pressed, we want to increment/decrement by 10x the step
+  const computedStep = useMemo(() => {
+    if (step !== undefined) {
+      return step * (isShiftPressed ? 10 : 1);
+    }
+    return isShiftPressed ? 10 : 1;
+  }, [step, isShiftPressed]);
 
   const rootClasses = classnames(commonCss.root, {
     [className]: className,
@@ -93,7 +103,7 @@ export const NumberInput = props => {
               onChange={handleOnChange}
               min={min ? "" + min : min}
               max={max ? "" + max : max}
-              step={step ? "" + step : step}
+              step={computedStep ? "" + computedStep : computedStep}
               name={name}
               value={value.toFixed(decimalDigits)}
             />
@@ -136,7 +146,7 @@ export const NumberInput = props => {
             autoComplete={autocomplete}
             min={min ? "" + min : min}
             max={max ? "" + max : max}
-            step={step ? "" + step : step}
+            step={computedStep ? "" + computedStep : computedStep}
             onChange={handleOnChange}
             onFocus={handleOnFocus}
             onBlur={handleOnBlur}

--- a/packages/ui-components/src/util/useShiftKey.js
+++ b/packages/ui-components/src/util/useShiftKey.js
@@ -1,0 +1,26 @@
+import { useState, useEffect } from "react";
+
+export const useShiftKey = () => {
+  const [isShiftPressed, setIsShiftPressed] = useState(false);
+
+  useEffect(() => {
+    const handleKeyDown = e => {
+      if (e.key === "Shift") {
+        setIsShiftPressed(true);
+      }
+    };
+    const handleKeyUp = e => {
+      if (e.key === "Shift") {
+        setIsShiftPressed(false);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keyup", handleKeyUp);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keyup", handleKeyUp);
+    };
+  }, []);
+
+  return isShiftPressed;
+};


### PR DESCRIPTION
## Context
Bringing this change over from #160, so it can be reviewed and potentially merged without being blocked by the bigger refactor to the validation flow proposed in #160.

## What this does
- This addresses #159, holding shift will cause the number input to increment by step * 10 using the arrow keys

Closes #159 