### PR TITLE
Add timestamp to frameloop

### DIFF
--- a/packages/core/src/mechanic-drawloop.js
+++ b/packages/core/src/mechanic-drawloop.js
@@ -70,9 +70,9 @@ class MechanicDrawloop {
   renderFrame(frame) {
     // We can easily calculate the timestamp of the current frame by multiplying
     // the current framecount with the fpsInterval. This yields the timestamp
-    // in milliseconds.
-    const time = frame * this.fpsInterval;
-    if (this.callback) this.callback({ frame, time });
+    // in milliseconds. So dividing by 1000 to get a more usable unit.
+    const time = (frame * this.fpsInterval) / 1000;
+    if (this.callback) this.callback({ frameCount: frame, timestamp: time });
   }
 
   /**

--- a/packages/core/src/mechanic-drawloop.js
+++ b/packages/core/src/mechanic-drawloop.js
@@ -68,7 +68,11 @@ class MechanicDrawloop {
    * @param {number} frame - The number of the frame to render
    */
   renderFrame(frame) {
-    if (this.callback) this.callback(frame);
+    // We can easily calculate the timestamp of the current frame by multiplying
+    // the current framecount with the fpsInterval. This yields the timestamp
+    // in milliseconds.
+    const time = frame * this.fpsInterval;
+    if (this.callback) this.callback({ frame, time });
   }
 
   /**

--- a/packages/create-mechanic/function-examples/instagram-story-generator/index.js
+++ b/packages/create-mechanic/function-examples/instagram-story-generator/index.js
@@ -43,7 +43,7 @@ export const handler = ({ inputs, done, frame, useDrawLoop }) => {
   // this is an array where will  store the circles
   const circles = [];
 
-  for (let i = 0; i < Math.min(Math.floor(frameCount / 15), 20); i++) {
+  for (let i = 0; i < Math.min(Math.floor(timestamp * 4), 20); i++) {
     circles.push(
       <Circle
         key={i}

--- a/packages/create-mechanic/function-examples/instagram-story-generator/index.js
+++ b/packages/create-mechanic/function-examples/instagram-story-generator/index.js
@@ -19,19 +19,18 @@ export const handler = ({ inputs, done, frame, useDrawLoop }) => {
 
   // stuff needed for the looping
   const isPlaying = useRef(true);
-  const frameCount = useDrawLoop(isPlaying.current);
+  const { timestamp } = useDrawLoop(isPlaying.current);
   const lines = text.split(" ");
-  const durationInFrames = duration * 60;
 
   // function to determine when to end the animation
   useEffect(() => {
-    if (durationInFrames > frameCount) {
+    if (duration > timestamp) {
       frame();
     } else if (isPlaying.current) {
       isPlaying.current = false;
       done();
     }
-  }, [frameCount]);
+  }, [timestamp]);
 
   // colors and font sizes
   const textColor = backgroundColor;

--- a/packages/create-mechanic/function-templates/canvas-video/index.js
+++ b/packages/create-mechanic/function-templates/canvas-video/index.js
@@ -4,11 +4,18 @@ export const handler = async ({ inputs, frame, done, drawLoop, getCanvas }) => {
 
   const center = [width / 2, height / 2];
   const radius = ((height / 2) * radiusPercentage) / 100;
-  let angle = 0;
 
   const { ctx } = getCanvas(width, height);
 
-  drawLoop(() => {
+  // frameCount has the number of the current frame, this is based on the framerate
+  // your animation is running it. For 60fps the frame at 1 seconds will be 60, whie
+  // at 24 fps it will be 24.
+  //
+  // timestamp has the frame offset in seconds and is always the same, no matter the
+  // framerate.
+  drawLoop(({ frameCount, timestamp }) => {
+    const angle = Math.PI * timestamp;
+
     ctx.fillStyle = "#F4F4F4";
     ctx.fillRect(0, 0, width, height);
 
@@ -32,12 +39,13 @@ export const handler = async ({ inputs, frame, done, drawLoop, getCanvas }) => {
     ctx.fillStyle = "#000000";
     ctx.font = `${height / 10}px sans-serif`;
     ctx.textAlign = "center";
-    ctx.strokeText(text, width / 2, height - height / 20);
-    ctx.fillText(text, width / 2, height - height / 20);
+
+    const textWithFrameCount = `${text} ${frameCount}`;
+    ctx.strokeText(textWithFrameCount, width / 2, height - height / 20);
+    ctx.fillText(textWithFrameCount, width / 2, height - height / 20);
 
     if (angle < turns * 2 * Math.PI) {
       frame();
-      angle += (2 * Math.PI) / 100;
     } else {
       done();
     }

--- a/packages/create-mechanic/function-templates/canvas-video/index.js
+++ b/packages/create-mechanic/function-templates/canvas-video/index.js
@@ -8,7 +8,7 @@ export const handler = async ({ inputs, frame, done, drawLoop, getCanvas }) => {
   const { ctx } = getCanvas(width, height);
 
   // frameCount has the number of the current frame, this is based on the framerate
-  // your animation is running it. For 60fps the frame at 1 seconds will be 60, whie
+  // your animation is running it. For 60 fps the frame at 1 seconds will be 60, while
   // at 24 fps it will be 24.
   //
   // timestamp has the frame offset in seconds and is always the same, no matter the

--- a/packages/create-mechanic/function-templates/react-video/index.js
+++ b/packages/create-mechanic/function-templates/react-video/index.js
@@ -11,7 +11,7 @@ export const handler = ({ inputs, frame, done, useDrawLoop }) => {
   const isPlaying = useRef(true);
 
   // frameCount has the number of the current frame, this is based on the framerate
-  // your animation is running it. For 60fps the frame at 1 seconds will be 60, whie
+  // your animation is running it. For 60 fps the frame at 1 seconds will be 60, while
   // at 24 fps it will be 24.
   //
   // timestamp has the frame offset in seconds and is always the same, no matter the

--- a/packages/create-mechanic/function-templates/react-video/index.js
+++ b/packages/create-mechanic/function-templates/react-video/index.js
@@ -9,17 +9,24 @@ export const handler = ({ inputs, frame, done, useDrawLoop }) => {
   const angle = useRef(0);
 
   const isPlaying = useRef(true);
-  const frameCount = useDrawLoop(isPlaying.current);
+
+  // frameCount has the number of the current frame, this is based on the framerate
+  // your animation is running it. For 60fps the frame at 1 seconds will be 60, whie
+  // at 24 fps it will be 24.
+  //
+  // timestamp has the frame offset in seconds and is always the same, no matter the
+  // framerate.
+  const { frameCount, timestamp } = useDrawLoop(isPlaying.current);
 
   useEffect(() => {
     if (angle.current < turns * 360) {
       frame();
-      angle.current += 360 / 100;
+      angle.current = 180 * timestamp;
     } else if (isPlaying.current) {
       isPlaying.current = false;
       done();
     }
-  }, [frameCount]);
+  }, [timestamp]);
 
   return (
     <svg width={width} height={height}>
@@ -45,7 +52,7 @@ export const handler = ({ inputs, frame, done, useDrawLoop }) => {
           fontFamily="sans-serif"
           fontSize={height / 10}
         >
-          {text}
+          {text} {frameCount}
         </text>
       </g>
     </svg>

--- a/packages/create-mechanic/function-templates/svg-video/index.js
+++ b/packages/create-mechanic/function-templates/svg-video/index.js
@@ -6,7 +6,7 @@ export const handler = ({ inputs, frame, done, drawLoop }) => {
   const radius = ((height / 2) * radiusPercentage) / 100;
 
   // frameCount has the number of the current frame, this is based on the framerate
-  // your animation is running it. For 60fps the frame at 1 seconds will be 60, whie
+  // your animation is running it. For 60 fps the frame at 1 seconds will be 60, while
   // at 24 fps it will be 24.
   //
   // timestamp has the frame offset in seconds and is always the same, no matter the

--- a/packages/create-mechanic/function-templates/svg-video/index.js
+++ b/packages/create-mechanic/function-templates/svg-video/index.js
@@ -5,8 +5,15 @@ export const handler = ({ inputs, frame, done, drawLoop }) => {
   const center = [width / 2, height / 2];
   const radius = ((height / 2) * radiusPercentage) / 100;
 
-  let angle = 0;
-  drawLoop(() => {
+  // frameCount has the number of the current frame, this is based on the framerate
+  // your animation is running it. For 60fps the frame at 1 seconds will be 60, whie
+  // at 24 fps it will be 24.
+  //
+  // timestamp has the frame offset in seconds and is always the same, no matter the
+  // framerate.
+  drawLoop(({ frameCount, timestamp }) => {
+    const angle = 180 * timestamp;
+
     const svg = `<svg width="${width}" height="${height}">
       <rect fill="#F4F4F4" width="${width}" height="${height}" />
       <g transform="translate(${center[0]}, ${center[1]})">
@@ -30,14 +37,13 @@ export const handler = ({ inputs, frame, done, drawLoop }) => {
           font-family="sans-serif"
           font-size="${height / 10}"
         >
-          ${text}
+          ${text} ${frameCount}
         </text>
       </g>
     </svg>`;
 
     if (angle < turns * 360) {
       frame(svg);
-      angle += 360 / 100;
     } else {
       done(svg);
     }

--- a/packages/dsi-logo-maker/functions/fillAnimatedCanvas/index.js
+++ b/packages/dsi-logo-maker/functions/fillAnimatedCanvas/index.js
@@ -54,12 +54,12 @@ export const handler = async ({ inputs, frame, done, drawLoop, getCanvas }) => {
     ctx.restore();
   };
 
-  drawLoop(frameCount => {
+  drawLoop(({ timestamp }) => {
     let changed = false;
     blockConfigs.forEach(blockConfigs => {
       const { block, animation } = blockConfigs;
       const currentProgress = Math.floor(
-        2 * animation.loops * block.cols * (frameCount / duration)
+        2 * animation.loops * block.cols * (timestamp / duration)
       );
       if (currentProgress > animation.progress) {
         animation.progress = currentProgress;
@@ -76,7 +76,7 @@ export const handler = async ({ inputs, frame, done, drawLoop, getCanvas }) => {
       draw();
     }
 
-    if (frameCount < duration) {
+    if (timestamp < duration) {
       frame();
     } else {
       done();
@@ -110,10 +110,11 @@ export const inputs = {
   },
   duration: {
     type: "number",
-    default: 300,
-    step: 10,
-    min: 10,
-    label: "Duration in frames"
+    default: 3,
+    step: 0.1,
+    min: 1,
+    max: 10,
+    label: "Duration in seconds"
   },
   fontMode: {
     type: "text",

--- a/packages/dsi-logo-maker/functions/fillAnimatedSVG/index.js
+++ b/packages/dsi-logo-maker/functions/fillAnimatedSVG/index.js
@@ -14,7 +14,7 @@ export const handler = ({ inputs, frame, done, useDrawLoop }) => {
 
   const [state, setState] = useState("loading");
   const font = useLoadedOpentypeFont(fontMode);
-  const frameCount = useDrawLoop(state === "playing");
+  const { timestamp } = useDrawLoop(state === "playing");
 
   const rows = 2;
   const cols = 13;
@@ -72,14 +72,14 @@ export const handler = ({ inputs, frame, done, useDrawLoop }) => {
 
   useEffect(() => {
     if (state === "playing") {
-      if (frameCount < duration) {
+      if (timestamp < duration) {
         frame();
       } else {
         setState("stopped");
         done();
       }
     }
-  }, [frameCount, state, setState]);
+  }, [timestamp, state, setState]);
 
   const { blockConfigs } = blockParams;
   return (
@@ -93,7 +93,7 @@ export const handler = ({ inputs, frame, done, useDrawLoop }) => {
             blockIndex={blockIndex}
             colors={colors}
             animation={animation}
-            runtime={frameCount}
+            runtime={timestamp}
           ></Unit>
         ))}
     </svg>
@@ -126,10 +126,10 @@ export const inputs = {
   },
   duration: {
     type: "number",
-    default: 300,
-    step: 20,
-    min: 10,
-    label: "Duration in frames"
+    default: 3,
+    step: 0.1,
+    min: 1,
+    label: "Duration in seconds"
   },
   fontMode: {
     type: "text",

--- a/packages/dsi-logo-maker/functions/logoAnimatedCanvas/index.js
+++ b/packages/dsi-logo-maker/functions/logoAnimatedCanvas/index.js
@@ -58,16 +58,14 @@ export const handler = async ({ inputs, frame, done, getCanvas, drawLoop }) => {
   let internalOffset = 0;
   let progress = 0;
 
-  drawLoop(frameCount => {
-    let currentProgress = Math.floor(
-      2 * loops * cols * (frameCount / duration)
-    );
+  drawLoop(({ timestamp }) => {
+    let currentProgress = Math.floor(2 * loops * cols * (timestamp / duration));
     if (currentProgress > progress) {
       progress = currentProgress;
       internalOffset = internalOffset + 1;
       draw();
     }
-    if (frameCount < duration) {
+    if (timestamp < duration) {
       frame();
     } else {
       done();
@@ -135,10 +133,11 @@ export const inputs = {
   },
   duration: {
     type: "number",
-    default: 300,
-    step: 10,
-    min: 10,
-    label: "Duration in frames"
+    default: 3,
+    step: 0.1,
+    min: 1,
+    max: 10,
+    label: "Duration in seconds"
   },
   loops: {
     type: "number",

--- a/packages/dsi-logo-maker/functions/logoAnimatedSVG/index.js
+++ b/packages/dsi-logo-maker/functions/logoAnimatedSVG/index.js
@@ -27,7 +27,7 @@ export const handler = ({ inputs, frame, done, useDrawLoop }) => {
   const progress = useRef(0);
   const [state, setState] = useState("loading");
   const font = useLoadedOpentypeFont(fontMode);
-  const frameCount = useDrawLoop(state === "playing");
+  const { timestamp } = useDrawLoop(state === "playing");
 
   const rows = 2;
   const cols = 13;
@@ -75,11 +75,9 @@ export const handler = ({ inputs, frame, done, useDrawLoop }) => {
 
   useEffect(() => {
     if (state === "playing") {
-      if (frameCount < duration) {
+      if (timestamp < duration) {
         frame();
-        let currentProgress = Math.floor(
-          2 * loops * cols * (frameCount / duration)
-        );
+        let currentProgress = Math.floor(2 * loops * cols * timestamp);
         if (currentProgress > progress.current) {
           progress.current = currentProgress;
           setInternalOffset(internalOffset => internalOffset + 1);
@@ -89,7 +87,7 @@ export const handler = ({ inputs, frame, done, useDrawLoop }) => {
         done();
       }
     }
-  }, [frameCount]);
+  }, [timestamp]);
 
   return (
     <svg width={width} height={height}>
@@ -101,7 +99,7 @@ export const handler = ({ inputs, frame, done, useDrawLoop }) => {
           blockIndex={brickIndex}
           colors={colors}
           animation={animation}
-          runtime={frameCount}
+          runtime={timestamp}
         ></Unit>
       )}
     </svg>
@@ -161,10 +159,11 @@ export const inputs = {
   },
   duration: {
     type: "number",
-    default: 300,
-    step: 10,
-    min: 10,
-    label: "Duration in frames"
+    default: 3,
+    step: 0.1,
+    min: 1,
+    max: 20,
+    label: "Duration in seconds"
   },
   loops: {
     type: "number",

--- a/packages/dsi-logo-maker/functions/textAnimatedCanvas/index.js
+++ b/packages/dsi-logo-maker/functions/textAnimatedCanvas/index.js
@@ -52,17 +52,15 @@ export const handler = async ({ inputs, getCanvas, done, frame, drawLoop }) => {
   let internalOffset = 0;
   let progress = 0;
 
-  drawLoop(frameCount => {
-    let currentProgress = Math.floor(
-      2 * loops * cols * (frameCount / duration)
-    );
+  drawLoop(({ timestamp }) => {
+    let currentProgress = Math.floor(2 * loops * cols * (timestamp / duration));
 
     if (currentProgress > progress) {
       progress = currentProgress;
       internalOffset = internalOffset + 1;
       draw();
     }
-    if (frameCount < duration) {
+    if (timestamp < duration) {
       frame();
     } else {
       done();
@@ -122,10 +120,11 @@ export const inputs = {
   },
   duration: {
     type: "number",
-    default: 600,
-    min: 10,
-    step: 10,
-    label: "Duration in Frames"
+    default: 6,
+    min: 1,
+    max: 10,
+    step: 0.1,
+    label: "Duration in Seconds"
   },
   loops: {
     type: "number",

--- a/packages/engine-canvas/CHANGELOG.md
+++ b/packages/engine-canvas/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Expose `getCanvas` util to design function. This will create a preview canvas that is adjusted to render crisp on the current display’s pixelDensity.
+- Expose `drawLoop` util to design function. This will call a callback determined by the `frameRate` and pass `frameCount` and `timestamp` in as arguments.
 
 ### Changed
 

--- a/packages/engine-react/CHANGELOG.md
+++ b/packages/engine-react/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Provides a `useDrawLoop` helper to design functions
+- Provides a `useDrawLoop` helper to design functions. It destructures to `frameCount` and `timestamp`. Both are updated determined by the pace of `frameRate`
 
 ### Changed
 

--- a/packages/engine-react/index.js
+++ b/packages/engine-react/index.js
@@ -12,7 +12,10 @@ const head = document.querySelector("head");
 const makeDrawLoop =
   drawLoop =>
   (isPlaying = true) => {
-    const [frameCount, setFrameCount] = useState(0);
+    const [animationProgress, setAnimationProgress] = useState({
+      frameCount: 0,
+      timestamp: 0
+    });
 
     useEffect(() => {
       if (!isPlaying) {
@@ -20,12 +23,12 @@ const makeDrawLoop =
         return;
       }
 
-      drawLoop.start(setFrameCount);
+      drawLoop.start(setAnimationProgress);
 
       return () => drawLoop.stop();
     }, [isPlaying]);
 
-    return frameCount;
+    return animationProgress;
   };
 
 export const run = (functionName, func, values, config) => {

--- a/packages/engine-svg/CHANGELOG.md
+++ b/packages/engine-svg/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Expose `drawLoop` util to design function. This will call a callback determined by the `frameRate` and pass `frameCount` and `timestamp` in as arguments.
+
 ### Changed
 
 - Updated engine to new `registerFrameCallback` and `registerDoneCallback` setup


### PR DESCRIPTION
## TL;DR

This calculates the timestamp of the current frame based on the current frame number and the framerate and sends this information to the design function via the newly added `drawLoop` (or `useDrawLoop`) helpers.

## Context

Thinking of animation as a series of frames is great from a technical standpoint, but not always easy to wrap your head around as someone building the animation. Additionally, depending on your framerate the exact same frame can have a different number within the same animation. (The 1 second frame is frame 60 at 60fps, but only 24 at 24 fps).

A more natural way to think about this is the time offset of a frame. So referring to a frame of animation to be the frame at 1 seconds time offset for example.

To add this ability to the new Animation API propose passing both the `frameCount` and the `timestamp` (in seconds, see below) to the callback a user provides to `drawLoop`. For React this means the return value of `useDrawLoop` can be destructured to `{ frameCount, timestamp }`.

Timestamp calculation is simple if you know the framerate and the number of the current frame. To get the offset in seconds means to divide the current frame count by the framerate. All of these information are available in the newly added drawLoop util of the new animation API, so calculating the timestamp is just one extra line of code there.

**Why seconds**: I chose to go with seconds (instead of milliseconds), as seconds feel more natural to understand. Sub-second intervals could still be specified by using floating point numbers throughout your code.

## What this does

- adds `timestamp` calculation to the draw Loop util
- passes `timestamp` to the drawloop's callback
- refactors DSI logo maker animation to use the `timestamp` instead of `frameCount`
- updates the animated function templates to show how both `frameCount` and `timestamp` can be obtained from the drawloop

## What does this mean?

In your design functions you can now do this:

```js
// frameCount has the number of the current frame, this is based on the framerate
// your animation is running it. For 60fps the frame at 1 seconds will be 60, while
// at 24 fps it will be 24.
//
// timestamp has the frame offset in seconds and is always the same, no matter the
// framerate.
drawLoop(({ frameCount, timestamp }) => {
  // You can now use the timestamp (in seconds) to determine animation progress
  // or define the finalization criteria of your animation

  // This will update the angle, so for each second there is 180° of rotation, no matter the frameRate
  const rotationAngle = 180 * timestamp;

  // Finalize after 10 seconds
  if (timestamp > 10) mechanic.done();
});
```

## Why is this cool?

As you know, I'm a big fan of frame based animation. At least, that's what I thought. I came to realize that actually I'm a huge fan of what I'd call "deterministic animation", where each frame is a pure function. It took me some time to understand that this isn't strictly tied to using frame numbers for animation. IMHO this addition to the new Animation API makes it easier to write animation frames as pure functions while working with "mental categories" (read "seconds") that you're familiar with from everyday life.