### PR TITLE
Little create-mechanic fix

### DIFF
--- a/packages/create-mechanic/CHANGELOG.md
+++ b/packages/create-mechanic/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Missing line break was added finalizing creating a DF.
+
 ## 2.0.0-beta.10 - 2023-02-10
 
 ### Fixed

--- a/packages/create-mechanic/script-content.js
+++ b/packages/create-mechanic/script-content.js
@@ -112,7 +112,7 @@ To start you now can run:
   }${
     !installation
       ? "\n> `npm run dev` or `yarn run dev`"
-      : `\`${installation.installingMethod} run dev\``
+      : `\n> \`${installation.installingMethod} run dev\``
   }
 `,
   bye: mechanicInverse,
@@ -134,7 +134,7 @@ To start you now can run:${
   }${
     !installation
       ? "\n> `npm run dev` or `yarn run dev`"
-      : `\`${installation.installingMethod} run dev\``
+      : `\n> \`${installation.installingMethod} run dev\``
   }
   `
 };


### PR DESCRIPTION
There was a little line break and `>` character missing in the create-mechanic flow when a user installs after creating the design function. This adds them!