### PR TITLE
feat(core): adds hideFunction setting

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Adds the setting to hide a design function from the mechanic UI app. This allows to iterate multiple functions and simply hide earlier versions, instead of moving everything to other locations. If a user sets `hideFunction` in their functions settings to true, they won't appear but will still be tracked for updates in HMR mode. It defaults to false.
+
 ## 2.0.0-beta.10 - 2023-02-10
 
 ### Added

--- a/packages/core/app/App.js
+++ b/packages/core/app/App.js
@@ -7,6 +7,7 @@ import { Nav } from "./components/Nav.js";
 import Feedback from "./components/Feedback.js";
 
 import functions from "./FUNCTIONS";
+const theresNoFunctions = Object.keys(functions).length === 0;
 
 import * as css from "./App.module.css";
 
@@ -62,18 +63,24 @@ const AppComponent = () => {
             )}
           />
         ))}
+
         <Route
           exact
           path="/"
-          render={() => (
-            <Layout
-              funcName={firstFunctionName}
-              functions={functions}
-              iframeRef={iframe}
-              mainRef={mainRef}
-            />
-          )}
+          render={() =>
+            !theresNoFunctions ? (
+              <Layout
+                funcName={firstFunctionName}
+                functions={functions}
+                iframeRef={iframe}
+                mainRef={mainRef}
+              />
+            ) : (
+              <NotFound theresNoFunctions={theresNoFunctions} />
+            )
+          }
         />
+
         <Route component={NotFound} />
       </Switch>
     </div>

--- a/packages/core/app/components/NotFound.js
+++ b/packages/core/app/components/NotFound.js
@@ -3,12 +3,18 @@ import { Link } from "react-router-dom";
 
 import * as css from "./NotFound.module.css";
 
-export const NotFound = () => {
+export const NotFound = ({ theresNoFunctions }) => {
   return (
     <div className={css.root}>
-      <p>
-        URL not found! Go <Link to="/">home</Link>.
-      </p>
+      {theresNoFunctions ? (
+        <p>
+          There's no Design Functions to show! Create a new one or un-hide some!
+        </p>
+      ) : (
+        <p>
+          URL not found! Go <Link to="/">home</Link>.
+        </p>
+      )}
     </div>
   );
 };

--- a/packages/core/app/function-loader.cjs
+++ b/packages/core/app/function-loader.cjs
@@ -20,9 +20,16 @@ module.exports = function () {
 
   const result = `
 ${importSection}
-export default {
+
+const allFunctions = {
   ${codeSection}
 };
+
+const functions = Object.fromEntries(
+  Object.entries(allFunctions).filter(([name, func]) => !func.settings.hideFunction)
+);
+
+export default functions;
 `;
   // console.log(result);
   return result;


### PR DESCRIPTION
This was something I've encountered a couple times myself while doing prototypes in mechanic. I create a bunch of design functions, trying different stuff, until I get to a final definite design function. To hide all other early explorations, I have to manually move everything out of the `functions/` folder. But adding this setting, let's us just hide with a setting quickly, and keep track of them even in HMR mode.