### PR TITLE
Module string missing appropiate cross-os treatment

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Adds the setting to hide a design function from the mechanic UI app. This allows to iterate multiple functions and simply hide earlier versions, instead of moving everything to other locations. If a user sets `hideFunction` in their functions settings to true, they won't appear but will still be tracked for updates in HMR mode. It defaults to false.
 
+### Fixed
+
+- Fixes bug that crushed mechanic on PC, because of a module string that wasn't appropriately made cross-os compatible. 
+
+
 ## 2.0.0-beta.10 - 2023-02-10
 
 ### Added

--- a/packages/core/src/commands/utils.cjs
+++ b/packages/core/src/commands/utils.cjs
@@ -64,7 +64,9 @@ const inputsPath = path.resolve(
   path.join(__dirname, "..", "..", "app", "INPUTS")
 );
 const getFuncScriptContent = designFunctionPath => `
-import { inputsDefs, inputErrors } from "${inputsPath}";
+import { inputsDefs, inputErrors } from "${inputsPath
+  .split(path.sep)
+  .join("/")}";
 import * as designFunction from "${designFunctionPath
   .split(path.sep)
   .join("/")}";


### PR DESCRIPTION
This fixes #181, which happened cause there was a missing path string treatment in a generated script string. The generate code was trying to import input code from a nonsensical string path. 

I tested in on my local PC partition and this fixed it!