### PR TITLE
Pass isPreview boolean prop to design function

### DIFF
--- a/packages/engine-canvas/CHANGELOG.md
+++ b/packages/engine-canvas/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Expose `isPreview` to design function.
+
 ## 2.0.0-beta.0 - 2022-03-16
 
 ### Added

--- a/packages/engine-canvas/index.js
+++ b/packages/engine-canvas/index.js
@@ -40,7 +40,8 @@ export const run = (functionName, func, values, config) => {
       done: onDone,
       state: mechanic.functionState,
       setState: onSetState
-    }
+    },
+    isPreview
   });
   return mechanic;
 };

--- a/packages/engine-p5/CHANGELOG.md
+++ b/packages/engine-p5/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Expose `isPreview` to design function.
+
 ## 2.0.0-beta.0 - 2022-03-16
 
 ### Added

--- a/packages/engine-p5/index.js
+++ b/packages/engine-p5/index.js
@@ -37,7 +37,8 @@ export const run = (functionName, func, values, config) => {
           state: mechanic.functionState,
           setState: onSetState
         },
-        sketch
+        sketch,
+        isPreview
       }),
     root
   );

--- a/packages/engine-react/CHANGELOG.md
+++ b/packages/engine-react/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Expose `isPreview` to design function.
+
 ## 2.0.0-beta.0 - 2022-03-16
 
 ### Added

--- a/packages/engine-react/index.js
+++ b/packages/engine-react/index.js
@@ -33,6 +33,7 @@ export const run = (functionName, func, values, config) => {
         state: mechanic.functionState,
         setState: onSetState
       }}
+      isPreview={isPreview}
     />,
     root
   );

--- a/packages/engine-svg/CHANGELOG.md
+++ b/packages/engine-svg/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Expose `isPreview` to design function.
+
 ## 2.0.0-beta.0 - 2022-03-16
 
 ### Added

--- a/packages/engine-svg/index.js
+++ b/packages/engine-svg/index.js
@@ -34,7 +34,8 @@ export const run = (functionName, func, values, config) => {
       done: onDone,
       state: mechanic.functionState,
       setState: onSetState
-    }
+    },
+    isPreview
   });
   return mechanic;
 };


### PR DESCRIPTION
This PR changes all existing mechanic engines to pass the `isPreview` to the design function. It's added as a new prop and can be destructured in the design function’s handler.

This is useful if for example you want to render guidelines in preview, but don’t want to include them in the final export.

Closes #189 