### PR TITLE
fix: ui-components latest version in dependencies

### DIFF
--- a/packages/create-mechanic/function-examples/adaptive-grid/dependencies.json
+++ b/packages/create-mechanic/function-examples/adaptive-grid/dependencies.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "@mechanic-design/engine-react": "^2.0.0-beta.11",
-    "@mechanic-design/ui-components": "^2.0.0-beta.11"
+    "@mechanic-design/ui-components": "^2.0.0-beta.10"
   }
 }

--- a/packages/create-mechanic/updateVersions.js
+++ b/packages/create-mechanic/updateVersions.js
@@ -19,6 +19,7 @@ const path = require("path");
     projectTemplatePkgPath,
     JSON.stringify(projectTemplatePkg, null, 2) + "\n"
   );
+  console.log(`Updated: ${path.relative(__dirname, projectTemplatePkgPath)}`);
 
   for (const directory of ["function-templates", "function-examples"]) {
     const bases = fs
@@ -26,6 +27,7 @@ const path = require("path");
       .filter(d => d !== "index.js");
 
     for (const base of bases) {
+      console.log(`\nTraversing: ${base}`);
       const dependenciesPath = path.join(
         __dirname,
         directory,
@@ -33,7 +35,10 @@ const path = require("path");
         `dependencies.json`
       );
       // skip if file doesn't exist
-      if (!fs.existsSync(dependenciesPath)) continue;
+      if (!fs.existsSync(dependenciesPath)) {
+        console.log(`Skipping: ${path.relative(__dirname, dependenciesPath)}`);
+        continue;
+      }
 
       const dependencies = require(dependenciesPath);
 
@@ -52,6 +57,7 @@ const path = require("path");
         dependenciesPath,
         JSON.stringify(dependencies, null, 2) + "\n"
       );
+      console.log(`Updated: ${path.relative(__dirname, dependenciesPath)}`);
     }
   }
 })();


### PR DESCRIPTION
I realized while testing `create-mechanic` locally that the version I added for `ui-components` in the last comment in #175 doesn't exists. This fixes it. It also adds some logs on the `updateVersions.js` script, that I used to fix this, just to make sure everything was working. 